### PR TITLE
Load data when loading banks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ CMakeLists.txt
 bin/
 *.os
 *.o
+*.obj
 
 # Clion specific
 

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -172,10 +172,8 @@ void Fmod::checkLoadingBanks() {
         FMOD_STUDIO_LOADING_STATE *loading_state = nullptr;
         checkErrors(bank->getLoadingState(loading_state));
         if (*loading_state == FMOD_STUDIO_LOADING_STATE_LOADED) {
-            int size = 0;
-            checkErrors(bank->getPath(nullptr, 0, &size));
-            char path[size];
-            checkErrors(bank->getPath(path, size, nullptr));
+            char path[MAX_BANK_PATH_SIZE];
+            checkErrors(bank->getPath(path, MAX_BANK_PATH_SIZE, nullptr));
             loadAllBuses(bank);
             loadAllVCAs(bank);
             loadAllEventDescriptions(bank);
@@ -510,86 +508,67 @@ void Fmod::stopAllBusEvents(const String busPath, int stopMode) {
 }
 
 void Fmod::loadAllVCAs(FMOD::Studio::Bank *bank) {
-    int count = 0;
-    if (checkErrors(bank->getVCACount(&count))) {
-        FMOD::Studio::VCA *array[count];
-        if (checkErrors(bank->getVCAList(array, count, &count))) {
-            for (int i = 0; i < count; i++) {
-                FMOD::Studio::VCA *vca = array[i];
-                int size = 0;
-                checkErrors(vca->getPath(nullptr, 0, &size));
-                char path[size];
-                checkErrors(vca->getPath(path, size, nullptr));
-                VCAs[path] << vca;
-            }
+    FMOD::Studio::VCA *array[MAX_VCA_PATH_COUNT];
+    if (checkErrors(bank->getVCAList(array, MAX_VCA_PATH_COUNT, nullptr))) {
+        for (auto vca : array) {
+            char path[MAX_VCA_PATH_SIZE];
+            checkErrors(vca->getPath(path, MAX_VCA_PATH_SIZE, nullptr));
+            VCAs[path] << vca;
         }
     }
 }
 
 void Fmod::loadAllBuses(FMOD::Studio::Bank *bank) {
-    int count = -1;
-    if (checkErrors(bank->getBusCount(&count))) {
-        FMOD::Studio::Bus *array[count];
-        if (checkErrors(bank->getBusList(array, count, &count))) {
-            for (int i = 0; i < count; i++) {
-                FMOD::Studio::Bus *bus = array[i];
-                int size = 0;
-                checkErrors(bus->getPath(nullptr, 0, &size));
-                char path[size];
-                checkErrors(bus->getPath(path, size, nullptr));
-                buses[path] << bus;
-            }
+    FMOD::Studio::Bus *array[MAX_BUS_PATH_COUNT];
+    if (checkErrors(bank->getBusList(array, MAX_BUS_PATH_COUNT, nullptr))) {
+        for (auto bus : array) {
+            char path[MAX_BUS_PATH_SIZE];
+            checkErrors(bus->getPath(path, MAX_BUS_PATH_SIZE, nullptr));
+            buses[path] << bus;
         }
     }
 }
 
 void Fmod::loadAllEventDescriptions(FMOD::Studio::Bank *bank) {
-    int count = -1;
-    if (checkErrors(bank->getEventCount(&count))) {
-        FMOD::Studio::EventDescription *array[count];
-        if (checkErrors(bank->getEventList(array, count, &count))) {
-            for (int i = 0; i < count; i++) {
-                FMOD::Studio::EventDescription *eventDescription = array[i];
-                int size = 0;
-                checkErrors(eventDescription->getPath(nullptr, 0, &size));
-                char path[size];
-                checkErrors(eventDescription->getPath(path, size, nullptr));
-                eventDescriptions[path] << eventDescription;
-            }
+    FMOD::Studio::EventDescription *array[MAX_EVENT_PATH_COUNT];
+    if (checkErrors(bank->getEventList(array, MAX_EVENT_PATH_COUNT, nullptr))) {
+        for (auto eventDescription : array) {
+            char path[MAX_EVENT_PATH_SIZE];
+            checkErrors(eventDescription->getPath(path, MAX_EVENT_PATH_SIZE, nullptr));
+            eventDescriptions[path] << eventDescription;
         }
     }
 }
 
 void Fmod::unloadAllVCAs(FMOD::Studio::Bank *bank) {
-    int count = -1;
-    if (checkErrors(bank->getVCACount(&count))) {
-        FMOD::Studio::VCA *array[count];
-        if (checkErrors(bank->getVCAList(array, count, &count))) {
-            for (int i = 0; i < count; i++) {
-                FMOD::Studio::VCA *vca = array[i];
-                int size = 0;
-                checkErrors(vca->getPath(nullptr, 0, &size));
-                char path[size];
-                checkErrors(vca->getPath(path, size, nullptr));
-                VCAs.erase(path);
-            }
+    FMOD::Studio::VCA *array[MAX_VCA_PATH_COUNT];
+    if (checkErrors(bank->getVCAList(array, MAX_VCA_PATH_COUNT, nullptr))) {
+        for (auto vca : array) {
+            char path[MAX_VCA_PATH_SIZE];
+            checkErrors(vca->getPath(path, MAX_VCA_PATH_SIZE, nullptr));
+            VCAs.erase(path);
         }
     }
 }
 
 void Fmod::unloadAllBuses(FMOD::Studio::Bank *bank) {
-    int count = -1;
-    if (checkErrors(bank->getBusCount(&count))) {
-        FMOD::Studio::Bus *array[count];
-        if (checkErrors(bank->getBusList(array, count, &count))) {
-            for (int i = 0; i < count; i++) {
-                FMOD::Studio::Bus *bus = array[i];
-                int size = 0;
-                checkErrors(bus->getPath(nullptr, 0, &size));
-                char path[size];
-                checkErrors(bus->getPath(path, size, nullptr));
-                VCAs.erase(path);
-            }
+    FMOD::Studio::Bus *array[MAX_BUS_PATH_COUNT];
+    if (checkErrors(bank->getBusList(array, MAX_BUS_PATH_COUNT, nullptr))) {
+        for (auto bus : array) {
+            char path[MAX_BUS_PATH_SIZE];
+            checkErrors(bus->getPath(path, MAX_BUS_PATH_SIZE, nullptr));
+            buses.erase(path);
+        }
+    }
+}
+
+void Fmod::unloadAllEventDescriptions(FMOD::Studio::Bank *bank) {
+    FMOD::Studio::EventDescription *array[MAX_EVENT_PATH_COUNT];
+    if (checkErrors(bank->getEventList(array, MAX_EVENT_PATH_COUNT, nullptr))) {
+        for (auto eventDescription : array) {
+            char path[MAX_EVENT_PATH_SIZE];
+            checkErrors(eventDescription->getPath(path, MAX_EVENT_PATH_SIZE, nullptr));
+            eventDescriptions.erase(path);
         }
     }
 }
@@ -602,25 +581,8 @@ bool Fmod::checkBusPath(const String busPath) {
     return buses.has(busPath);
 }
 
-bool Fmod::checkEventPath(String eventPath) {
+bool Fmod::checkEventPath(const String eventPath) {
     return eventDescriptions.has(eventPath);
-}
-
-void Fmod::unloadAllEventDescriptions(FMOD::Studio::Bank *bank) {
-    int count = -1;
-    if (checkErrors(bank->getEventCount(&count))) {
-        FMOD::Studio::EventDescription *array[count];
-        if (checkErrors(bank->getEventList(array, count, &count))) {
-            for (int i = 0; i < count; i++) {
-                FMOD::Studio::EventDescription *eventDescription = array[i];
-                int size = 0;
-                checkErrors(eventDescription->getPath(nullptr, 0, &size));
-                char path[size];
-                checkErrors(eventDescription->getPath(path, size, nullptr));
-                eventDescriptions.erase(path);
-            }
-        }
-    }
 }
 
 FMOD::Studio::EventInstance *Fmod::createInstance(const String eventName, const bool isOneShot, Object *gameObject) {

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -168,7 +168,7 @@ void Fmod::update() {
 
 void Fmod::checkLoadingBanks() {
     for (int i = 0; i < loadingBanks.size(); i++) {
-        auto bank = (FMOD::Studio::Bank *) (uint64_t) loadingBanks.pop_front();
+        auto bank = loadingBanks.pop_front_value();
         FMOD_STUDIO_LOADING_STATE *loading_state = nullptr;
         checkErrors(bank->getLoadingState(loading_state));
         if (*loading_state == FMOD_STUDIO_LOADING_STATE_LOADED) {
@@ -179,7 +179,7 @@ void Fmod::checkLoadingBanks() {
             loadAllEventDescriptions(bank);
             banks[path] << bank;
         } else if (*loading_state == FMOD_STUDIO_LOADING_STATE_LOADING) {
-            loadingBanks.push_back((uint64_t) bank);
+            loadingBanks.push_back_value(bank);
         } else if (*loading_state == FMOD_STUDIO_LOADING_STATE_ERROR) {
             Godot::print_error("Fmod Sound System: Error loading bank.", BOOST_CURRENT_FUNCTION, __FILE__, __LINE__);
         }
@@ -834,6 +834,7 @@ void Fmod::setSound3DSettings(float dopplerScale, float distanceFactor, float ro
 
 void Fmod::waitForAllLoads() {
     checkErrors(system->flushSampleLoading());
+    checkLoadingBanks();
 }
 
 Array Fmod::getAvailableDrivers() {
@@ -843,11 +844,11 @@ Array Fmod::getAvailableDrivers() {
     checkErrors(coreSystem->getNumDrivers(&numDrivers));
 
     for (int i = 0; i < numDrivers; i++) {
-        char name[256];
+        char name[MAX_DRIVER_NAME_SIZE];
         int sampleRate;
         FMOD_SPEAKERMODE speakerMode;
         int speakerModeChannels;
-        checkErrors(coreSystem->getDriverInfo(i, name, 256, nullptr, &sampleRate, &speakerMode, &speakerModeChannels));
+        checkErrors(coreSystem->getDriverInfo(i, name, MAX_DRIVER_NAME_SIZE, nullptr, &sampleRate, &speakerMode, &speakerModeChannels));
         String nameStr(name);
 
         Dictionary driverInfo;

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -28,13 +28,16 @@ if (!instance) { \
 #define MACRO_CHOOSER(...) FUNC_RECOMPOSER((__VA_ARGS__, FIND_AND_CHECK_WITH_RETURN, FIND_AND_CHECK_WITHOUT_RETURN, ))
 #define FIND_AND_CHECK(...) MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
-#define MAX_BANK_PATH_SIZE 512
-#define MAX_VCA_PATH_SIZE 512
-#define MAX_BUS_PATH_SIZE 512
-#define MAX_EVENT_PATH_SIZE 512
-#define MAX_VCA_PATH_COUNT 64
-#define MAX_BUS_PATH_COUNT 64
-#define MAX_EVENT_PATH_COUNT 256
+#define MAX_PATH_SIZE 512
+#define MAX_VCA_COUNT 64
+#define MAX_BUS_COUNT 64
+#define MAX_EVENT_COUNT 256
+
+#define CHECK_SIZE(maxSize, actualSize, type) \
+if(actualSize > maxSize){\
+    Godot::print_error("FMOD Sound System: type maximum size is maxSize but the bank contains actualSize entries", BOOST_CURRENT_FUNCTION, __FILE__, __LINE__);\
+    actualSize = maxSize;\
+}\
 
 namespace godot {
 
@@ -113,7 +116,7 @@ namespace godot {
         void shutdown();
         void addListener(Object *gameObj);
         void setSoftwareFormat(int sampleRate, int speakerMode, int numRawSpeakers);
-        String loadbank(String pathToBank, unsigned int flag);
+        String loadBank(const String pathToBank, const unsigned int flag);
         void unloadBank(String pathToBank);
         bool checkVCAPath(String vcaPath);
         bool checkBusPath(String busPath);

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -79,8 +79,6 @@ namespace godot {
         FMOD_3D_ATTRIBUTES get3DAttributes(const FMOD_VECTOR &pos, const FMOD_VECTOR &up, const FMOD_VECTOR &forward,
                                            const FMOD_VECTOR &vel);
         bool isNull(Object *o);
-        void loadBus(const String &busPath);
-        void loadVCA(const String &VCAPath);
         void updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Object *o);
         void runCallbacks();
 
@@ -90,6 +88,9 @@ namespace godot {
         void loadAllVCAs(FMOD::Studio::Bank *bank);
         void loadAllBuses(FMOD::Studio::Bank *bank);
         void loadAllEventDescriptions(FMOD::Studio::Bank *bank);
+        void unloadAllVCAs(FMOD::Studio::Bank *bank);
+        void unloadAllBuses(FMOD::Studio::Bank *bank);
+        void unloadAllEventDescriptions(FMOD::Studio::Bank *bank);
 
     public:
         Fmod();
@@ -106,6 +107,9 @@ namespace godot {
         void setSoftwareFormat(int sampleRate, int speakerMode, int numRawSpeakers);
         String loadbank(String pathToBank, unsigned int flag);
         void unloadBank(String pathToBank);
+        bool checkVCAPath(String vcaPath);
+        bool checkBusPath(String busPath);
+        bool checkEventPath(String eventPath);
         int getBankLoadingState(String pathToBank);
         int getBankBusCount(String pathToBank);
         int getBankEventCount(String pathToBank);

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -39,7 +39,6 @@ namespace godot {
         Callbacks::CallbackInfo callbackInfo = Callbacks::CallbackInfo();
     };
 
-
     struct SoundChannel {
         FMOD::Sound *sound;
         FMOD::Channel *channel;
@@ -60,6 +59,7 @@ namespace godot {
 
         bool nullListenerWarning = true;
 
+        Vector<FMOD::Studio::Bank *> loadingBanks;
         Map<String, FMOD::Studio::Bank *> banks;
         Map<String, FMOD::Studio::EventDescription *> eventDescriptions;
         Map<String, FMOD::Studio::Bus *> buses;
@@ -73,6 +73,7 @@ namespace godot {
 
     private:
         int checkErrors(FMOD_RESULT result);
+        void checkLoadingBanks();
         void setListenerAttributes();
         FMOD_VECTOR toFmodVector(Vector3 &vec);
         FMOD_3D_ATTRIBUTES get3DAttributes(const FMOD_VECTOR &pos, const FMOD_VECTOR &up, const FMOD_VECTOR &forward,
@@ -86,6 +87,9 @@ namespace godot {
         FMOD::Studio::EventInstance *createInstance(String eventName, bool isOneShot, Object *gameObject);
         EventInfo *getEventInfo(FMOD::Studio::EventInstance *eventInstance);
         void releaseOneEvent(FMOD::Studio::EventInstance *eventInstance);
+        void loadAllVCAs(FMOD::Studio::Bank *bank);
+        void loadAllBuses(FMOD::Studio::Bank *bank);
+        void loadAllEventDescriptions(FMOD::Studio::Bank *bank);
 
     public:
         Fmod();

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -32,6 +32,7 @@ if (!instance) { \
 #define MAX_VCA_COUNT 64
 #define MAX_BUS_COUNT 64
 #define MAX_EVENT_COUNT 256
+#define MAX_DRIVER_NAME_SIZE 256
 
 #define CHECK_SIZE(maxSize, actualSize, type) \
 if(actualSize > maxSize){\

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -28,6 +28,14 @@ if (!instance) { \
 #define MACRO_CHOOSER(...) FUNC_RECOMPOSER((__VA_ARGS__, FIND_AND_CHECK_WITH_RETURN, FIND_AND_CHECK_WITHOUT_RETURN, ))
 #define FIND_AND_CHECK(...) MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
+#define MAX_BANK_PATH_SIZE 512
+#define MAX_VCA_PATH_SIZE 512
+#define MAX_BUS_PATH_SIZE 512
+#define MAX_EVENT_PATH_SIZE 512
+#define MAX_VCA_PATH_COUNT 64
+#define MAX_BUS_PATH_COUNT 64
+#define MAX_EVENT_PATH_COUNT 256
+
 namespace godot {
 
     struct EventInfo {

--- a/src/helpers/containers.h
+++ b/src/helpers/containers.h
@@ -60,7 +60,7 @@ namespace godot {
             return nullptr;
         }
 
-        friend void  operator<<<V>(Variant &var, V &value);
+        friend void operator<<<V>(Variant &var, V &value);
     };
 
 }

--- a/src/helpers/containers.h
+++ b/src/helpers/containers.h
@@ -38,10 +38,17 @@ namespace godot {
             return var;
         }
 
-        uint64_t erase(const T value){
+        void erase(const T value){
             const auto var = (uint64_t) value;
             Array::erase(var);
-            return var;
+        }
+
+        T pop_front_value(){
+            return (T) ((uint64_t) Array::pop_front());
+        }
+
+        void push_back_value(const T &v){
+            Array::push_back((uint64_t) v);
         }
 
     };


### PR DESCRIPTION
Load VCAs, buses, and event descriptions when loading banks.
Unload them when unloading bank.
Helper methods to check if vca, bus or event descriptions is valid according to banks loaded.