### PR TITLE
Modify of Linux library to same path as in release

### DIFF
--- a/demo/addons/fmod/Fmod.gdnlib
+++ b/demo/addons/fmod/Fmod.gdnlib
@@ -10,7 +10,7 @@ reloadable=true
 Android.arm64-v8a="res://addons/fmod/libs/android/arm64_v8a/libGodotFmod.android.release.arm64-v8a.so"
 OSX.64="res://addons/fmod/libs/osx/libGodotFmod.osx.release.64.dylib"
 Windows.64="res://addons/fmod/libs/windows/libGodotFmod.windows.release.64.dll"
-X11.64="res://addons/fmod/libs/linux/libGodotFmod.linux.so"
+X11.64="res://addons/fmod/libs/linux/libGodotFmod.linux.release.so"
 iOS.arm64="res://addons/fmod/libs/iOS/libGodotFmod.ios.release.arm64.a"
 
 [dependencies]


### PR DESCRIPTION
Path of Linux library in this file was:
`X11.64="res://addons/fmod/libs/linux/libGodotFmod.linux.so"`

But the file downloaded from the Releases has following name:
`libGodotFmod.linux.release.so`

Probably a left-over from testing?