### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ FMOD.play_one_shot_attached("event:/Footstep", self)
 
 # same as play_one_shot_attached but lets you set initial parameters
 # subsequent parameters cannot be set
-FMOD.play_one_shot_Attached_with_params("event:/Footstep", self, { "Surface": 1.0, "Speed": 2.0 })
+FMOD.play_one_shot_attached_with_params("event:/Footstep", self, { "Surface": 1.0, "Speed": 2.0 })
 
 # attaches a manually called instance to a Node
 # once attached 3D attributes are automatically set every frame (when update is called)

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ func _ready():
 	Fmod.load_bank("res://Music.bank", Fmod.FMOD_STUDIO_LOAD_BANK_NORMAL)
 	
 	# register listener
-	Fmod.add_listener($Listener)
+	Fmod.add_listener(0, $Listener)
 	
 	# Create event instance
 	var my_music_event = Fmod.create_event_instance("event:/Weapons/Machine Gun")


### PR DESCRIPTION
The function `add_listener()` requires the first argument to be the index of the listener.

I could be mistaken, but this is the only instance of this function where the first argument is neglected.