### PR TITLE
Change Object to Node and add additional type check.

### DIFF
--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -188,8 +188,8 @@ func get_global_parameter_desc_list() -> Array:
 ###LISTENERS###
 ###############
 
-func add_listener(index: int, object: Node) -> void:
-	godot_fmod.add_listener(index, object)
+func add_listener(index: int, node: Node) -> void:
+	godot_fmod.add_listener(index, node)
 
 func remove_listener(index: int) -> void:
 	godot_fmod.remove_listener(index)
@@ -224,7 +224,7 @@ func set_listener_lock(index: int, is_locked: bool) -> void:
 func get_listener_lock(index: int) -> bool:
 	return godot_fmod.get_listener_lock(index)
 
-func get_object_attached_to_listener(index: int) -> Object:
+func get_object_attached_to_listener(index: int) -> Node:
 	return godot_fmod.get_object_attached_to_listener(index)
 ##########
 ###BANK###
@@ -257,17 +257,17 @@ func banks_still_loading() -> bool:
 ####################
 ###EVENT_INSTANCE###
 ####################
-func play_one_shot(event_path: String, object) -> void:
-	godot_fmod.play_one_shot(event_path, object)
+func play_one_shot(event_path: String, node: Node) -> void:
+	godot_fmod.play_one_shot(event_path, node)
 
-func play_one_shot_with_params(event_path: String, object, params: Dictionary) -> void:
-	godot_fmod.play_one_shot_with_params(event_path, object, params)
+func play_one_shot_with_params(event_path: String, node: Node, params: Dictionary) -> void:
+	godot_fmod.play_one_shot_with_params(event_path, node, params)
 
-func play_one_shot_attached(event_path: String, object) -> void:
-	godot_fmod.play_one_shot_attached(event_path, object)
+func play_one_shot_attached(event_path: String, node: Node) -> void:
+	godot_fmod.play_one_shot_attached(event_path, node)
 
-func play_one_shot_attached_with_params(event_path: String, object: Object, params: Dictionary) -> void:
-	godot_fmod.play_one_shot_attached_with_params(event_path, object, params)
+func play_one_shot_attached_with_params(event_path: String, node: Node, params: Dictionary) -> void:
+	godot_fmod.play_one_shot_attached_with_params(event_path, node, params)
 
 func create_event_instance(event_path: String) -> int:
 	return godot_fmod.create_event_instance(event_path)
@@ -299,13 +299,13 @@ func get_event_pitch(instanceId: int) -> float:
 func set_event_pitch(instanceId: int, pitch: float) -> void:
 	godot_fmod.set_event_pitch(instanceId, pitch)
 
-func attach_instance_to_node(instanceId: int, object: Object) -> void:
-	godot_fmod.attach_instance_to_node(instanceId, object)
+func attach_instance_to_node(instanceId: int, node: Node) -> void:
+	godot_fmod.attach_instance_to_node(instanceId, node)
 
 func detach_instance_from_node(instanceId: int) -> void:
 	godot_fmod.detach_instance_from_node(instanceId)
 
-func get_object_attached_to_instance(instanceId: int) -> Object:
+func get_object_attached_to_instance(instanceId: int) -> Node:
 	return godot_fmod.get_object_attached_to_instance(instanceId)
 
 func get_event_parameter_by_name(instanceId: int, parameterName: String) -> float:

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -273,13 +273,17 @@ void Fmod::setListenerAttributes() {
             ERROR_CHECK(system->setListenerWeight(i, 0));
             continue;
         }
-        auto *ci = Node::cast_to<CanvasItem>(listener->gameObj);
+        Node *node = listener->gameObj;
+        if(!node->is_inside_tree()){
+            return;
+        }
+        auto *ci = Node::cast_to<CanvasItem>(node);
         if (ci != nullptr) {
             auto attr = get3DAttributesFromTransform2D(ci->get_global_transform());
             ERROR_CHECK(system->setListenerAttributes(i, &attr));
             continue;
         }
-        auto *s = Node::cast_to<Spatial>(listener->gameObj);
+        auto *s = Node::cast_to<Spatial>(node);
         if (s != nullptr) {
             auto attr = get3DAttributesFromTransform(s->get_global_transform());
             ERROR_CHECK(system->setListenerAttributes(i, &attr));
@@ -372,16 +376,16 @@ bool Fmod::isFmodValid(Node *node) {
     return false;
 }
 
-void Fmod::updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Node *o) {
+void Fmod::updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Node *node) {
     // try to set 3D attributes
-    if (instance && isFmodValid(o)) {
-        auto *ci = Node::cast_to<CanvasItem>(o);
+    if (instance && isFmodValid(node) && node->is_inside_tree()) {
+        auto *ci = Node::cast_to<CanvasItem>(node);
         if (ci != nullptr) {
             auto attr = get3DAttributesFromTransform2D(ci->get_global_transform());
             ERROR_CHECK(instance->set3DAttributes(&attr));
             return;
         }
-        auto *s = Node::cast_to<Spatial>(o);
+        auto *s = Node::cast_to<Spatial>(node);
         if (s != nullptr) {
             auto attr = get3DAttributesFromTransform(s->get_global_transform());
             ERROR_CHECK(instance->set3DAttributes(&attr));

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -273,18 +273,19 @@ void Fmod::setListenerAttributes() {
             ERROR_CHECK(system->setListenerWeight(i, 0));
             continue;
         }
-        Node *node = listener->gameObj;
+
+        Node* node {listener->gameObj};
         if(!node->is_inside_tree()){
             return;
         }
-        auto *ci = Node::cast_to<CanvasItem>(node);
-        if (ci != nullptr) {
+
+        if (auto *ci {Node::cast_to<CanvasItem>(node)}) {
             auto attr = get3DAttributesFromTransform2D(ci->get_global_transform());
             ERROR_CHECK(system->setListenerAttributes(i, &attr));
             continue;
         }
-        auto *s = Node::cast_to<Spatial>(node);
-        if (s != nullptr) {
+
+        if (auto *s {Node::cast_to<Spatial>(node)}) {
             auto attr = get3DAttributesFromTransform(s->get_global_transform());
             ERROR_CHECK(system->setListenerAttributes(i, &attr));
             continue;
@@ -379,14 +380,12 @@ bool Fmod::isFmodValid(Node *node) {
 void Fmod::updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Node *node) {
     // try to set 3D attributes
     if (instance && isFmodValid(node) && node->is_inside_tree()) {
-        auto *ci = Node::cast_to<CanvasItem>(node);
-        if (ci != nullptr) {
+        if (auto *ci {Node::cast_to<CanvasItem>(node)}) {
             auto attr = get3DAttributesFromTransform2D(ci->get_global_transform());
             ERROR_CHECK(instance->set3DAttributes(&attr));
             return;
         }
-        auto *s = Node::cast_to<Spatial>(node);
-        if (s != nullptr) {
+        if (auto *s {Node::cast_to<Spatial>(node)}) {
             auto attr = get3DAttributesFromTransform(s->get_global_transform());
             ERROR_CHECK(instance->set3DAttributes(&attr));
             return;

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -71,7 +71,7 @@ namespace godot {
         //Is the event oneshot
         bool isOneShot = false;
         //GameObject to which this event is attached
-        Object *gameObj = nullptr;
+        Node *gameObj = nullptr;
         // Callback info associated with this event
         Callbacks::CallbackInfo callbackInfo = Callbacks::CallbackInfo();
     };
@@ -82,7 +82,7 @@ namespace godot {
     };
 
     struct Listener {
-        Object *gameObj = nullptr;
+        Node *gameObj = nullptr;
         bool listenerLock = false;
         float weight = 1.0;
     };
@@ -132,12 +132,12 @@ namespace godot {
         Dictionary getTransformInfoFrom3DAttribut(FMOD_3D_ATTRIBUTES &attribut);
         Dictionary getTransform2DInfoFrom3DAttribut(FMOD_3D_ATTRIBUTES &attribut);
 
-        static bool isDead(Object* o);
-        static bool isFmodValid(Object* o);
-        void updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Object *o);
+        static bool isDead(Node *node);
+        static bool isFmodValid(Node *node);
+        void updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Node *o);
         void runCallbacks();
 
-        FMOD::Studio::EventInstance *createInstance(String eventName, bool isOneShot, Object *gameObject);
+        FMOD::Studio::EventInstance *createInstance(String eventName, bool isOneShot, Node *gameObject);
         EventInfo *getEventInfo(FMOD::Studio::EventInstance *eventInstance);
         void releaseOneEvent(FMOD::Studio::EventInstance *eventInstance);
         void loadBankData(LoadingBank *loadingBank);
@@ -163,7 +163,7 @@ namespace godot {
         void setSound3DSettings(float dopplerScale, float distanceFactor, float rollOffScale);
         void setSoftwareFormat(int sampleRate, int speakerMode, int numRawSpeakers);
 
-        void addListener(int index, Object *gameObj);
+        void addListener(int index, Node *gameObj);
         void removeListener(int index);
         void setListenerNumber(int listenerNumber);
         int getSystemNumListeners();
@@ -175,7 +175,7 @@ namespace godot {
         void setSystemListener2DAttributes(int index, Transform2D transform);
         void setListenerLock(int index, bool isLocked);
         bool getListenerLock(int index);
-        Object *getObjectAttachedToListener(int index);
+        Node * getObjectAttachedToListener(int index);
 
         String loadBank(String pathToBank, unsigned int flag);
         void unloadBank(String pathToBank);
@@ -252,13 +252,13 @@ namespace godot {
         float getVCAVolume(String VCAPath);
         void setVCAVolume(String VCAPath, float volume);
         /* Helper methods */
-        void playOneShot(String eventName, Object *gameObj);
-        void playOneShotWithParams(String eventName, Object *gameObj, Dictionary parameters);
-        void playOneShotAttached(String eventName, Object *gameObj);
-        void playOneShotAttachedWithParams(String eventName, Object *gameObj, Dictionary parameters);
-        void attachInstanceToNode(uint64_t instanceId, Object *gameObj);
+        void playOneShot(String eventName, Node *gameObj);
+        void playOneShotWithParams(String eventName, Node *gameObj, Dictionary parameters);
+        void playOneShotAttached(String eventName, Node *gameObj);
+        void playOneShotAttachedWithParams(String eventName, Node *gameObj, Dictionary parameters);
+        void attachInstanceToNode(uint64_t instanceId, Node *gameObj);
         void detachInstanceFromNode(uint64_t instanceId);
-        Object *getObjectAttachedToInstance(uint64_t instanceId);
+        Node * getObjectAttachedToInstance(uint64_t instanceId);
         void pauseAllEvents(bool pause);
         void muteAllEvents();
         void unmuteAllEvents();

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -175,7 +175,7 @@ namespace godot {
         void setSystemListener2DAttributes(int index, Transform2D transform);
         void setListenerLock(int index, bool isLocked);
         bool getListenerLock(int index);
-        Node * getObjectAttachedToListener(int index);
+        Node* getObjectAttachedToListener(int index);
 
         String loadBank(String pathToBank, unsigned int flag);
         void unloadBank(String pathToBank);
@@ -258,7 +258,7 @@ namespace godot {
         void playOneShotAttachedWithParams(String eventName, Node *gameObj, Dictionary parameters);
         void attachInstanceToNode(uint64_t instanceId, Node *gameObj);
         void detachInstanceFromNode(uint64_t instanceId);
-        Node * getObjectAttachedToInstance(uint64_t instanceId);
+        Node* getObjectAttachedToInstance(uint64_t instanceId);
         void pauseAllEvents(bool pause);
         void muteAllEvents();
         void unmuteAllEvents();

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -134,7 +134,7 @@ namespace godot {
 
         static bool isDead(Node *node);
         static bool isFmodValid(Node *node);
-        void updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Node *o);
+        void updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Node *node);
         void runCallbacks();
 
         FMOD::Studio::EventInstance *createInstance(String eventName, bool isOneShot, Node *gameObject);


### PR DESCRIPTION
Fix issue #60 

All exposed methods that previously used Object are now using Node as parameter/return type.
The node has to be either be a CanvasItem or a spatial, otherwise, an error is returned.