### PR TITLE
Add destructor to Fmod wrapper.

### DIFF
--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -4,7 +4,7 @@ signal timeline_marker
 signal sound_played
 signal sound_stopped
 
-var godot_fmod = FmodNative.new()
+var godot_fmod: FmodNative
 
 ############
 ###UTILS###
@@ -119,11 +119,16 @@ var started := false
 ###SYSTEM###
 ############
 func _init() -> void:
+	godot_fmod = FmodNative.new()
 	godot_fmod.connect("timeline_beat", self, "on_timeline_beat")
 	godot_fmod.connect("timeline_marker", self, "on_timeline_marker")
 	godot_fmod.connect("sound_played", self, "on_sound_played")
 	godot_fmod.connect("sound_stopped", self, "on_sound_stopped")
 	print("Fmod Gdnative interface managed by a GDScript wrapper")
+	
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		godot_fmod.free()
 
 func _process(delta):
 	if started:

--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -128,6 +128,8 @@ func _init() -> void:
 	
 func _notification(what):
 	if what == NOTIFICATION_PREDELETE:
+		if started:
+			shutdown()
 		godot_fmod.free()
 
 func _process(delta):
@@ -136,12 +138,18 @@ func _process(delta):
 
 
 func init(numOfChannels: int, studioFlag: int, fmodFlag: int) -> void:
-	godot_fmod.init(numOfChannels, studioFlag, fmodFlag)
-	started = true
+	if not started:
+		godot_fmod.init(numOfChannels, studioFlag, fmodFlag)
+		started = true
+	else:
+		print("Fmod already started")
 	
 func shutdown() -> void:
-	started = false
-	godot_fmod.shutdown()
+	if started:
+		started = false
+		godot_fmod.shutdown()
+	else:
+		print("Fmod not started, can't shutdown'")
 
 func set_software_format(sampleRate: int, speakerMode: int, numRowSpeakers: int) -> void:
 	godot_fmod.set_software_format(sampleRate, speakerMode, numRowSpeakers)

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -11,7 +11,6 @@ Mutex *Callbacks::mut;
 Fmod::Fmod() = default;
 
 Fmod::~Fmod() {
-    Fmod::shutdown();
     delete Callbacks::mut;
     Callbacks::mut = nullptr;
 }


### PR DESCRIPTION
Fix #58 

The autoload wrapper now has a destructor that will free the GDNative instance. 
No leak should happen when the game is closing with this fix.