### PR TITLE
Update Fmod.gdnlib

### DIFF
--- a/demo/addons/fmod/Fmod.gdnlib
+++ b/demo/addons/fmod/Fmod.gdnlib
@@ -10,7 +10,7 @@ reloadable=true
 Android.arm64-v8a="res://addons/fmod/libs/android/arm64_v8a/libGodotFmod.android.release.arm64-v8a.so"
 OSX.64="res://addons/fmod/libs/osx/libGodotFmod.osx.release.64.dylib"
 Windows.64="res://addons/fmod/libs/windows/libGodotFmod.windows.release.64.dll"
-X11.64="res://addons/fmod/libs/linux/libGodotFmod.linux.release.so"
+X11.64="res://addons/fmod/libs/linux/libGodotFmod.linux.release.64.so"
 iOS.arm64="res://addons/fmod/libs/iOS/libGodotFmod.ios.release.arm64.a"
 
 [dependencies]


### PR DESCRIPTION
Due to fatigue or just not paying attention I actually didn't fully fix the issue with the linux binaries' path being incorrect.

An additional .64 should be added to make it have the exact same name as the one in the release 👌 

Apologies!