### PR TITLE
Fix linux compilation flags

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -197,13 +197,14 @@ if env['platform'] == 'linux':
     if env['use_llvm']:
         env['CXX'] = 'clang++'
 
-    env.Append(CCFLAGS=['-fPIC', '-g', '-std=c++14', '-Wwrite-strings'])
+    env.Append(CCFLAGS=['-fPIC', '-std=c++14', '-Wwrite-strings'])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])
 
     if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og'])
+        env.Append(CCFLAGS=['-g3', '-Og'])
     elif env['target'] == 'release':
         env.Append(CCFLAGS=['-O3'])
+        env.Append(LINKFLAGS=['-s'])
 
     if env['bits'] == '64':
         env.Append(CCFLAGS=['-m64'])


### PR DESCRIPTION
This strips the Linux release libraries automatically, so no more humongous bloated sizes (= 40MB 😱 ), but a size more in line with libraries of other platforms (~3.3 MB 🥳 )

I tested this out on the Github Actions PR-branch and these are the results:
![image](https://user-images.githubusercontent.com/42484461/107026781-826a3880-67ab-11eb-84e3-fa9577a1aa96.png)

This PR closes https://github.com/utopia-rise/fmod-gdnative/issues/72
