### PR TITLE
add `verboseMode` & `is_stdout_verbose()` check to GODOT_LOG

### DIFF
--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -120,12 +120,13 @@ var started := false
 ############
 func _init() -> void:
 	godot_fmod = FmodNative.new()
+	godot_fmod.verbose_mode = verbose_mode
 	godot_fmod.connect("timeline_beat", self, "on_timeline_beat")
 	godot_fmod.connect("timeline_marker", self, "on_timeline_marker")
 	godot_fmod.connect("sound_played", self, "on_sound_played")
 	godot_fmod.connect("sound_stopped", self, "on_sound_stopped")
 	print("Fmod Gdnative interface managed by a GDScript wrapper")
-	
+
 func _notification(what):
 	if what == NOTIFICATION_PREDELETE:
 		if started:
@@ -541,7 +542,16 @@ func set_bus_volume(bus_path: String, volume: float) -> void:
 	
 func stop_all_bus_events(bus_path: String, stopMode: int) -> void:
 	godot_fmod.stop_all_bus_events(bus_path, stopMode)
-	
+
+#########
+###Variable###
+#########
+var verbose_mode : bool setget set_verbose_mode
+func set_verbose_mode(value : bool):
+	verbose_mode = value
+	if started:
+		godot_fmod.verbose_mode = verbose_mode
+
 #########
 ###Signal###
 #########

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -6,6 +6,8 @@
 
 using namespace godot;
 
+bool Fmod::verboseMode = true;
+
 Fmod::Fmod() = default;
 
 Fmod::~Fmod() {
@@ -139,12 +141,22 @@ void Fmod::_register_methods() {
     register_method("get_global_parameter_desc_list", &Fmod::getGlobalParameterDescList);
     register_method("_process", &Fmod::_process);
 
+    register_property<Fmod, bool>("verbose_mode", &Fmod::setVerboseMode, &Fmod::getVerboseMode, false);
+
     register_signal<Fmod>("timeline_beat", "params", GODOT_VARIANT_TYPE_DICTIONARY);
     register_signal<Fmod>("timeline_marker", "params", GODOT_VARIANT_TYPE_DICTIONARY);
     register_signal<Fmod>("sound_played", "params", GODOT_VARIANT_TYPE_DICTIONARY);
     register_signal<Fmod>("sound_stopped", "params", GODOT_VARIANT_TYPE_DICTIONARY);
 
     REGISTER_ALL_CONSTANTS
+}
+
+void Fmod::setVerboseMode(bool value) {
+    verboseMode = value;
+}
+
+bool Fmod::getVerboseMode() {
+    return verboseMode;
 }
 
 bool Fmod::checkErrors(FMOD_RESULT result, const char *function, const char *file, int line) {

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -11,6 +11,7 @@
 #include <Object.hpp>
 #include <CanvasItem.hpp>
 #include <Node.hpp>
+#include <OS.hpp>
 #include <gen/Mutex.hpp>
 #include "callback/event_callbacks.h"
 #include "callback/file_callbacks.h"
@@ -44,7 +45,9 @@ namespace godot {
 #define GODOT_LOG(level, message)\
     switch (level) {\
         case 0:\
-            Godot::print(message);\
+            if (verboseMode || OS::get_singleton()->is_stdout_verbose()){\
+                Godot::print(message);\
+            }\
             break;\
         case 1:\
             Godot::print_warning(message, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__);\
@@ -308,6 +311,10 @@ namespace godot {
         Array getGlobalParameterDescList();
 
         void setCallback(uint64_t instanceId, int callbackMask);
+
+        static bool verboseMode;
+        void setVerboseMode(bool value);
+        bool getVerboseMode();
     };
 }
 


### PR DESCRIPTION
This is my suggestion to add output suppression to the FMOD plugin as discussed in #74
I'm using two variables for following reason:

- Sometimes I want to see the FMOD output in the console without putting my Godot editor in verbose mode. Setting verbose stdout in Godot dumps to much other stuff to the console that might not be relevant to the matter at hand (= debugging FMOD issues)

- When running Godot in verbose mode (-v) you evidently want all FMOD output to be dumped to the console without having to set the verbose_mode to true.

Other proposals/modifications by owners are ofc welcome!