### PR TITLE
Add support for DSP buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,13 @@ Fmod.set_driver(id)
 var id = Fmod.get_driver()
 ```
 
+### Reducing audio playback latency
+
+You may encounter that the audio playback has some latency. This may be caused by the DSP buffer size. You can change the value **before** initialisation to adjust it:
+```gdscript
+Fmod.set_dsp_buffer_size(512, 4)
+```
+
 ### Profiling & querying performance data
 
 `getPerformanceData` returns an object which contains current performance stats for CPU, Memory and File Streaming usage of both FMOD Studio and the Core System.

--- a/README.md
+++ b/README.md
@@ -528,6 +528,10 @@ var id = Fmod.get_driver()
 You may encounter that the audio playback has some latency. This may be caused by the DSP buffer size. You can change the value **before** initialisation to adjust it:
 ```gdscript
 Fmod.set_dsp_buffer_size(512, 4)
+# retrieve the buffer length
+Fmod.get_dsp_buffer_length()
+# retrieve the number of buffers
+Fmod.get_dsp_num_buffers()
 ```
 
 ### Profiling & querying performance data

--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -199,6 +199,9 @@ func get_global_parameter_desc_list() -> Array:
 
 func set_dsp_buffer_size(bufferLength: int, numberOfBuffers: int) -> void:
 	godot_fmod.set_dsp_buffer_size(bufferLength, numberOfBuffers)
+	
+func get_dsp_buffer_size() -> Array:
+	return godot_fmod.get_dsp_buffer_size()
 
 func get_dsp_buffer_length() -> int:
 	return godot_fmod.get_dsp_buffer_length()

--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -197,6 +197,9 @@ func get_global_parameter_desc_count() -> int:
 func get_global_parameter_desc_list() -> Array:
 	return godot_fmod.get_global_parameter_desc_list()
 
+func set_dsp_buffer_size(bufferLength: int, numberOfBuffers: int) -> int:
+    return godot_fmod.set_dsp_buffer_size(bufferLength, numberOfBuffers)
+
 ###############
 ###LISTENERS###
 ###############

--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -197,8 +197,14 @@ func get_global_parameter_desc_count() -> int:
 func get_global_parameter_desc_list() -> Array:
 	return godot_fmod.get_global_parameter_desc_list()
 
-func set_dsp_buffer_size(bufferLength: int, numberOfBuffers: int) -> int:
-    return godot_fmod.set_dsp_buffer_size(bufferLength, numberOfBuffers)
+func set_dsp_buffer_size(bufferLength: int, numberOfBuffers: int) -> void:
+    godot_fmod.set_dsp_buffer_size(bufferLength, numberOfBuffers)
+
+func get_dsp_buffer_length() -> int:
+	return godot_fmod.get_dsp_buffer_length()
+
+func set_dsp_num_buffers() -> int:
+	return godot_fmod.get_dsp_num_buffers()
 
 ###############
 ###LISTENERS###

--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -198,12 +198,12 @@ func get_global_parameter_desc_list() -> Array:
 	return godot_fmod.get_global_parameter_desc_list()
 
 func set_dsp_buffer_size(bufferLength: int, numberOfBuffers: int) -> void:
-    godot_fmod.set_dsp_buffer_size(bufferLength, numberOfBuffers)
+	godot_fmod.set_dsp_buffer_size(bufferLength, numberOfBuffers)
 
 func get_dsp_buffer_length() -> int:
 	return godot_fmod.get_dsp_buffer_length()
 
-func set_dsp_num_buffers() -> int:
+func get_dsp_num_buffers() -> int:
 	return godot_fmod.get_dsp_num_buffers()
 
 ###############

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "Node",
+"base": "",
 "class": "FmodNative",
 "language": "NativeScript",
 "path": "res://addons/fmod/Fmod.gdns"

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "",
+"base": "Node",
 "class": "FmodNative",
 "language": "NativeScript",
 "path": "res://addons/fmod/Fmod.gdns"

--- a/demo/test/unit/test_ainit_fmod.gd
+++ b/demo/test/unit/test_ainit_fmod.gd
@@ -3,5 +3,6 @@ extends "res://addons/gut/test.gd"
 func before_all():
 	# set up FMOD
 	Fmod.set_software_format(0, Fmod.FMOD_SPEAKERMODE_STEREO, 0)
+	Fmod.set_dsp_buffer_size(512, 4)
 	Fmod.init(1024, Fmod.FMOD_STUDIO_INIT_LIVEUPDATE, Fmod.FMOD_INIT_NORMAL)
 	Fmod.set_sound_3D_settings(1, 32, 1)

--- a/demo/test/unit/test_global.gd
+++ b/demo/test/unit/test_global.gd
@@ -63,3 +63,9 @@ class TestGlobal:
 	func test_assert_should_have_dsp_num_buffers():
 		var num_buffers = Fmod.get_dsp_num_buffers()
 		assert_eq(num_buffers, 4)
+
+	func test_assert_should_have_dsp_buffer_size():
+		var buffer_size = Fmod.get_dsp_buffer_size()
+		assert_eq(buffer_size.size(), 2)
+		assert_eq(buffer_size[0], 512)
+		assert_eq(buffer_size[1], 4)

--- a/demo/test/unit/test_global.gd
+++ b/demo/test/unit/test_global.gd
@@ -55,3 +55,11 @@ class TestGlobal:
 	
 	func assert_contains_in_dict(dict: Dictionary, key: String):
 		assert_has(dict, key, "Performance data should contains " + key + " data")
+		
+	func test_assert_should_have_dsp_buffer_length():
+		var buffer_length = Fmod.get_dsp_buffer_length()
+		assert_eq(buffer_length, 512)
+		
+	func test_assert_should_have_dsp_num_buffers():
+		var num_buffers = Fmod.get_dsp_num_buffers()
+		assert_eq(num_buffers, 4)

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -136,6 +136,7 @@ void Fmod::_register_methods() {
     register_method("get_global_parameter_desc_by_id", &Fmod::getGlobalParameterDescByID);
     register_method("get_global_parameter_desc_count", &Fmod::getGlobalParameterDescCount);
     register_method("get_global_parameter_desc_list", &Fmod::getGlobalParameterDescList);
+    register_method("set_dsp_buffer_size", &Fmod::setSystemDSPBufferSize);
     register_method("_process", &Fmod::_process);
 
     register_signal<Fmod>("timeline_beat", "params", GODOT_VARIANT_TYPE_DICTIONARY);
@@ -1311,6 +1312,14 @@ Node * Fmod::getObjectAttachedToInstance(uint64_t instanceId) {
         }
     }
     return node;
+}
+
+void Fmod::setSystemDSPBufferSize(unsigned int bufferlength, int numbuffers) {
+    if (bufferlength > 0 && numbuffers > 0 && ERROR_CHECK(coreSystem->setDSPBufferSize(bufferlength, numbuffers))) {
+        GODOT_LOG(0, "FMOD Sound System: Successfully set DSP buffer size")
+    } else {
+        GODOT_LOG(2, "FMOD Sound System: Failed to set DSP buffer size :|")
+    }
 }
 
 void Fmod::pauseAllEvents(const bool pause) {

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -137,6 +137,7 @@ void Fmod::_register_methods() {
     register_method("get_global_parameter_desc_count", &Fmod::getGlobalParameterDescCount);
     register_method("get_global_parameter_desc_list", &Fmod::getGlobalParameterDescList);
     register_method("set_dsp_buffer_size", &Fmod::setSystemDSPBufferSize);
+    register_method("get_dsp_buffer_size", &Fmod::getSystemDSPBufferSize);
     register_method("get_dsp_buffer_length", &Fmod::getSystemDSPBufferLength);
     register_method("get_dsp_num_buffers", &Fmod::getSystemDSPNumBuffers);
     register_method("_process", &Fmod::_process);
@@ -1324,14 +1325,28 @@ void Fmod::setSystemDSPBufferSize(unsigned int bufferlength, int numbuffers) {
     }
 }
 
-int Fmod::getSystemDSPBufferLength() {
-    ERROR_CHECK(coreSystem->getDSPBufferSize(&this->bufferlength, &this->numbuffers));
-    return this->bufferlength;
+Array Fmod::getSystemDSPBufferSize() {
+    unsigned int bufferlength;
+    int numbuffers;
+    Array a;
+    ERROR_CHECK(coreSystem->getDSPBufferSize(&bufferlength, &numbuffers));
+    a.append(bufferlength);
+    a.append(numbuffers);
+    return a;
+}
+
+unsigned int Fmod::getSystemDSPBufferLength() {
+    unsigned int bufferlength;
+    int numbuffers;
+    ERROR_CHECK(coreSystem->getDSPBufferSize(&bufferlength, &numbuffers));
+    return bufferlength;
 }
 
 int Fmod::getSystemDSPNumBuffers() {
-    ERROR_CHECK(coreSystem->getDSPBufferSize(&this->bufferlength, &this->numbuffers));
-    return this->numbuffers;
+    unsigned int bufferlength;
+    int numbuffers;
+    ERROR_CHECK(coreSystem->getDSPBufferSize(&bufferlength, &numbuffers));
+    return numbuffers;
 }
 
 void Fmod::pauseAllEvents(const bool pause) {

--- a/src/godot_fmod.cpp
+++ b/src/godot_fmod.cpp
@@ -137,6 +137,8 @@ void Fmod::_register_methods() {
     register_method("get_global_parameter_desc_count", &Fmod::getGlobalParameterDescCount);
     register_method("get_global_parameter_desc_list", &Fmod::getGlobalParameterDescList);
     register_method("set_dsp_buffer_size", &Fmod::setSystemDSPBufferSize);
+    register_method("get_dsp_buffer_length", &Fmod::getSystemDSPBufferLength);
+    register_method("get_dsp_num_buffers", &Fmod::getSystemDSPNumBuffers);
     register_method("_process", &Fmod::_process);
 
     register_signal<Fmod>("timeline_beat", "params", GODOT_VARIANT_TYPE_DICTIONARY);
@@ -1320,6 +1322,16 @@ void Fmod::setSystemDSPBufferSize(unsigned int bufferlength, int numbuffers) {
     } else {
         GODOT_LOG(2, "FMOD Sound System: Failed to set DSP buffer size :|")
     }
+}
+
+int Fmod::getSystemDSPBufferLength() {
+    ERROR_CHECK(coreSystem->getDSPBufferSize(&this->bufferlength, &this->numbuffers));
+    return this->bufferlength;
+}
+
+int Fmod::getSystemDSPNumBuffers() {
+    ERROR_CHECK(coreSystem->getDSPBufferSize(&this->bufferlength, &this->numbuffers));
+    return this->numbuffers;
 }
 
 void Fmod::pauseAllEvents(const bool pause) {

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -183,6 +183,7 @@ namespace godot {
         void setListenerLock(int index, bool isLocked);
         bool getListenerLock(int index);
         Node* getObjectAttachedToListener(int index);
+        void setSystemDSPBufferSize(unsigned int bufferlength, int numbuffers);
 
         String loadBank(String pathToBank, unsigned int flag);
         void unloadBank(String pathToBank);

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -111,6 +111,8 @@ namespace godot {
         int actualListenerNumber = 0;
         Listener listeners[FMOD_MAX_LISTENERS];
         bool listenerWarning = true;
+        unsigned int bufferlength = 0;
+        int numbuffers = 0;
 
         Vector<LoadingBank *> loadingBanks;
         Map<String, FMOD::Studio::Bank *> banks;
@@ -184,6 +186,8 @@ namespace godot {
         bool getListenerLock(int index);
         Node* getObjectAttachedToListener(int index);
         void setSystemDSPBufferSize(unsigned int bufferlength, int numbuffers);
+        int getSystemDSPBufferLength();
+        int getSystemDSPNumBuffers();
 
         String loadBank(String pathToBank, unsigned int flag);
         void unloadBank(String pathToBank);

--- a/src/godot_fmod.h
+++ b/src/godot_fmod.h
@@ -111,8 +111,6 @@ namespace godot {
         int actualListenerNumber = 0;
         Listener listeners[FMOD_MAX_LISTENERS];
         bool listenerWarning = true;
-        unsigned int bufferlength = 0;
-        int numbuffers = 0;
 
         Vector<LoadingBank *> loadingBanks;
         Map<String, FMOD::Studio::Bank *> banks;
@@ -186,8 +184,9 @@ namespace godot {
         bool getListenerLock(int index);
         Node* getObjectAttachedToListener(int index);
         void setSystemDSPBufferSize(unsigned int bufferlength, int numbuffers);
-        int getSystemDSPBufferLength();
+        unsigned int getSystemDSPBufferLength();
         int getSystemDSPNumBuffers();
+        Array getSystemDSPBufferSize();
 
         String loadBank(String pathToBank, unsigned int flag);
         void unloadBank(String pathToBank);


### PR DESCRIPTION
As explained in https://github.com/utopia-rise/fmod-gdnative/issues/91 there is currently the issue on certain systems that the audio plays back with delay. The reason is that the default DSP buffer size has the wrong configuration.

This pull request allows to configure the DSP buffer size like so in Godot:
```gdscript
Fmod.set_dsp_buffer_size(512, 4)
Fmod.init(1024, Fmod.FMOD_STUDIO_INIT_LIVEUPDATE, Fmod.FMOD_INIT_NORMAL)
```
I tested this with my game and the audio playback latency is now near real-time. No more audible lag after setting this in my game code!

- [x] added GUT tests
- [x] updated README.md