### PR TITLE
Added macos universal build.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -152,6 +152,12 @@ opts.Add(
     'Path to the FMOD library',
     "../libs/fmod/"
 )
+opts.Add(EnumVariable(
+    'macos_arch',
+    'Target macOS architecture',
+    'universal',
+    ['universal', 'x86_64', 'arm64']
+))
 
 env = Environment(ENV = os.environ)
 opts.Update(env)
@@ -222,17 +228,23 @@ elif env['platform'] == 'osx':
             'Only 64-bit builds are supported for the macOS target.'
         )
 
-    env.Append(CCFLAGS=['-g', '-std=c++14', '-arch', 'x86_64'])
+    if env["macos_arch"] == "universal":
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+    else:
+        env.Append(LINKFLAGS=["-arch", env["macos_arch"]])
+        env.Append(CCFLAGS=["-arch", env["macos_arch"]])
+
+    env.Append(CCFLAGS=['-std=c++14'])
+
     env.Append(LINKFLAGS=[
-        '-arch',
-        'x86_64',
         '-framework',
         'Cocoa',
         '-Wl,-undefined,dynamic_lookup',
     ])
 
     if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og', 'g'])
+        env.Append(CCFLAGS=['-Og', '-g'])
     elif env['target'] == 'release':
         env.Append(CCFLAGS=['-O3'])
 


### PR DESCRIPTION
Added a new macos_arch build option that allows specifying universal, x86_64, or arm64 (apple silicon). This defaults to universal which includes both x86_64 and arm64 builds. Both the FMOD libraries and godot-cpp library provide macos universal builds now so this allows fmod-gdnative to be able to be built for and run on macos arm64 architecture.

Without these changes running a godot project with the fmod-gdnative library on macos arm64 gives the following error: `Can't open dynamic library: .../addons/fmod/libs/osx/libGodotFmod.osx.release.64.dylib, error: dlopen(.../addons/fmod/libs/osx/libGodotFmod.osx.release.64.dylib, 0x0002): tried: '.../addons/fmod/libs/osx/libGodotFmod.osx.release.64.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/lib/libGodotFmod.osx.release.64.dylib' (no such file).`
