### PR TITLE
:bug: add missing user property argument

### DIFF
--- a/demo/addons/fmod/Fmod.gd
+++ b/demo/addons/fmod/Fmod.gd
@@ -501,14 +501,14 @@ func desc_get_parameter_description_count(event_path: String) -> int:
 func desc_get_parameter_description_by_index(event_path: String) -> Dictionary:
 	return godot_fmod.desc_get_parameter_description_by_index(event_path)
 
-func desc_get_user_property(event_path: String) -> Dictionary:
-	return godot_fmod.desc_get_user_property(event_path)
+func desc_get_user_property(event_path: String, property_name: String) -> Dictionary:
+	return godot_fmod.desc_get_user_property(event_path, property_name)
 
 func desc_get_user_property_count(event_path: String) -> int:
 	return godot_fmod.desc_get_user_property_count(event_path)
 
-func desc_user_property_by_index(event_path: String) -> Dictionary:
-	return godot_fmod.desc_user_property_by_index(event_path)
+func desc_user_property_by_index(event_path: String, index: int) -> Dictionary:
+	return godot_fmod.desc_user_property_by_index(event_path, index)
 
 
 ###########

--- a/demo/test/unit/test_desc_event.gd
+++ b/demo/test/unit/test_desc_event.gd
@@ -73,3 +73,18 @@ class TestEventDescription:
 	func test_assert_sound_size():
 		var desiredValue: float = 2.0
 		assert_eq(Fmod.desc_get_sound_size("event:/Vehicles/Car Engine"), desiredValue, "Event description sound size should be " + str(desiredValue))
+		
+	func test_assert_should_retrieve_user_property_by_name():
+		var desiredSize: int = 0
+		var property = Fmod.desc_get_user_property("event:/Vehicles/Car Engine", "abc")
+		assert_eq(property.size(), desiredSize, "Number of user properties should be " + str(desiredSize))
+		
+	func test_assert_should_retrieve_user_property_by_index():
+		var desiredSize: int = 0
+		var property = Fmod.desc_user_property_by_index("event:/Vehicles/Car Engine", 0)
+		assert_eq(property.size(), desiredSize, "Number of user properties should be " + str(desiredSize))
+
+	func test_assert_should_retrieve_user_property_count():
+		var desiredSize: int = 0
+		var property = Fmod.desc_get_user_property_count("event:/Vehicles/Car Engine")
+		assert_eq(property, desiredSize, "Number of user properties should be " + str(desiredSize))


### PR DESCRIPTION
_addresses #103_

Add missing arguments to FMOD autoload methods.

- [x] code changes
- [x] GUT tests