### PR TITLE
:sparkles: preload sample data by default

### DIFF
--- a/demo/addons/fmod/nodes/FmodEventEmitter.gd
+++ b/demo/addons/fmod/nodes/FmodEventEmitter.gd
@@ -13,8 +13,7 @@ export(bool) var allow_fadeout = true
 export(bool) var preload_event = true
 
 var params = {}
-var event_id = UNDEFINED 
-var is_paused = false
+var event_id = UNDEFINED
 
 func _ready():
 	for key in params:
@@ -36,9 +35,14 @@ func _exit_tree():
 func set_param(key:String, value:float) -> void:
 	params[key] = value
 	_set_fmod_param(key, value)
+	
+func is_paused() -> bool:
+	if event_id == UNDEFINED:
+		return false
+	return Fmod.get_event_paused(event_id)
 
 func play() -> void:
-	if is_paused:
+	if is_paused():
 		_unpause()
 	elif looped:
 		_play_looped()
@@ -48,12 +52,10 @@ func play() -> void:
 func pause() -> void:
 	if event_id != UNDEFINED:
 		Fmod.set_event_paused(event_id, true)
-	is_paused = true
 	
 func _unpause() -> void:
 	if event_id != UNDEFINED:
 		Fmod.set_event_paused(event_id, false)
-	is_paused = false
 		
 func _play_one_shot() -> void:
 	if !attached:

--- a/demo/addons/fmod/nodes/FmodEventEmitter.gd
+++ b/demo/addons/fmod/nodes/FmodEventEmitter.gd
@@ -10,13 +10,17 @@ export(bool) var attached = true
 export(bool) var autoplay = false
 export(bool) var looped = false
 export(bool) var allow_fadeout = true
-export(Dictionary) var params
+export(bool) var preload_event = true
+
+var params = {}
 var event_id = UNDEFINED 
 var is_paused = false
 
 func _ready():
 	for key in params:
 		_set_fmod_param(key, params[key])
+	if event_id != UNDEFINED and preload_event:
+		Fmod.desc_load_sample_data(fmod_event_name)
 	if autoplay:
 		play()
 		
@@ -32,7 +36,6 @@ func _exit_tree():
 func set_param(key:String, value:float) -> void:
 	params[key] = value
 	_set_fmod_param(key, value)
-	
 
 func play() -> void:
 	if is_paused:
@@ -50,6 +53,7 @@ func pause() -> void:
 func _unpause() -> void:
 	if event_id != UNDEFINED:
 		Fmod.set_event_paused(event_id, false)
+	is_paused = false
 		
 func _play_one_shot() -> void:
 	if !attached:

--- a/demo/addons/fmod/nodes/FmodEventEmitter.gd
+++ b/demo/addons/fmod/nodes/FmodEventEmitter.gd
@@ -19,7 +19,7 @@ var is_paused = false
 func _ready():
 	for key in params:
 		_set_fmod_param(key, params[key])
-	if event_id != UNDEFINED and preload_event:
+	if preload_event:
 		Fmod.desc_load_sample_data(fmod_event_name)
 	if autoplay:
 		play()


### PR DESCRIPTION
The existing logic of `FmodEventEmitter` would never preload event data, leading to lag when playing event information for the first time. This is due to the fact that loading a bank will only load its metadata but not sample data for individual events. By default, instantiating a new node of type `FmodEventEmitter` will now preload its sample data. This can be disabled in the export.