### PR TITLE
Enhancement: split compiling and installing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,44 +19,10 @@ This fork was designed to be able to use Fmod without building Godot Engine !
 
 ![wowmeme]
 
-## Typical Project structure
-
-```
-└── Project root
-    ├── libs
-    |   └── fmod
-    |       └── {platform}
-    |           └── specific platform fmod api goes here
-    ├── godot-cpp (gdnative bindings, consider using a git submodule)
-    └── fmod-gdnative (this repo, consider using it as a submodule of you GDNatives repo)
-        ├── CMakeLists.txt (Here for CLion)
-        ├── LICENSE
-        ├── README.md
-        ├── SConstruct (here to build on Windows, Linux, OSX and IOS
-        └── src
-```
-
-If you look at [Sconstruct](SConstruct) script, you'll see that it refers to libraries that are in path relatives to
-parent folder. This is because Utopia-Rise team chose to make this repo integrated to a unique repository, storing all
-the GDNative for our project.
-
-So, you are supposed to put fmod libraries under `libs/fmod/{platform}`, according to the platforms you want to support.
-
-Otherwise, you can use [our example project](https://github.com/utopia-rise/GDNative-example-repo), which already contains the appropriate structure.
-
-Feel free to modify SConstruct according to your project structure.
-
-`CMakeLists` is here for CLion ide, as we are used to JetBrains tools. Unfortunately, CLion does not currently support
-Sconstruct.
-
-## Building the GDNative
-
-Current CI status : ![CI status](https://travis-ci.com/utopia-rise/fmod-gdnative.svg?branch=master)
-
 ### Continuous delivery
 
-This project uses Travis-CI to continuously deploy released drivers. If you use those releases, you can skip building
-api and driver. Installing is still necessary.  
+This project uses github actions to continuously deploy released drivers. If you do not want to use those releases, you
+can compile from sources by looking to [compile from sources section](./docs/COMPILING.md).  
 This project uses [SEMVER](https://semver.org/).
 
 #### OS Compatibility matrix :
@@ -93,123 +59,35 @@ This project uses [SEMVER](https://semver.org/).
 |      3.0.0     |         |    X    |         |
 |      3.x.x     |         |         |    X    |
 
-### Building GDNative API bindings
+## Installing the plugin in your project
 
-To Build GDNative bindings you can follow [this tutorial from godot official documentation](https://docs.godotengine.org/en/3.1/tutorials/plugins/gdnative/gdnative-cpp-example.html#building-the-c-bindings).
-If you want to regenerate api you can add the following argument to your building command :
-```
-godotbinpath="path to your godot binary"
-```
-When you're done with that part you should have `libgodot-cpp.<platform>.<target>.<bits|android_arch|ios_arch>.<a|lib>` in godot-cpp/bin` folder.
+### Install addon folder
 
-#### iOS
-
-To build bindings for iOS, execute:
-```
-scons platform=ios generate_bindings=True ios_arch=armv7/arm64 target=release
-```
-
-#### Android
-
-To build bindings for android, we provide our [godot-cpp](https://github.com/utopia-rise/godot-cpp) version. 
-Checkout `utopia-3.2` branch. This is also provided with our [GDNative example project](https://github.com/utopia-rise/GDNative-example-repo).  
-First, you should set `ANDROID_NDK_ROOT` environment variable by typing :
-```
-export ANDROID_NDK_ROOT="pathToYourAndroidNDK"
-```  
-To build on Android, you should type :
-```
-scons platform=android generate_bindings=True android_arch=armv7/arm64v8 target=release
-```
-
-### Building the GDNative driver
-
-[Download the FMOD Studio API](https://www.fmod.com/download) (You need to create an account) and place it in the
-appropriate platform folder into lib folder (see project structure).
-
-For each platforms, if your project structure is different from the one proposed here, you can overload `cpp_bindings_dir` 
-and `headers_dir` parameters.
-
-To load fmod dynamic libraries on app or engine loading, fmod GDNative will look in subfolder `libs` by default, as in OSX
-part. you can overload this relative path adding this parameter to the command `fmod_lib_dir="path to fmod dll"`. 
-
-#### OSX
-
-To build the GDNative for OSX, you should use this command in `fmod-gdnative` folder :
-
-```
-scons platform=osx target=release bits=64
-```
-
-This will generate `libGodotFmod.osx.release.64.dylib` in `fmod-gdnative/bin` folder. 
-
-
-#### Linux
-
-To build the GDNative for Linux, you should use this command in `fmod-gdnative` folder :
-```
-scons platform=linux use_llvm=yes target=release bits=64
-```
-This will generate a `libGodotFmod.linux.release.64.so` in `fmod-gdnative/bin` folder.
-
-#### Windows
-
-To build the GDNative for Windows, you should use this command in `fmod-gdnative` folder :
-```
-scons platform=windows target=release bits=64
-```
-This will generate `libGodotFmod.windows.release.64.dll` in `fmod-gdnative/bin` folder.
-
-#### Android
-
-To build the GDNative for Android, we currently use NDKBuild. So you should use this command in `fmod-gdnative` folder :
-```
-$ANDROID_NDK_ROOT/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=Android.mk  APP_PLATFORM=android-21
-```
-This will generate `libGodotFmod.android.<target>.<android_arch>.so` for each supported architectures in `libs` folder.
-
-#### iOS
-
-To build the GDNative for iOS, you should use this command in `fmod-gdnative` folder :
-```
-scons platform=ios target=release ios-arch=armv7/arm64
-```
-This will generate `libGodotFmod.ios.release.arm64.a` in `fmod-gdnative/bin` folder.
-
-Those libraries are statics, so you need to add fmod static librairies and godot-cpp static library for ios in your
-project, with `libGodotFmod.ios.release.arm64.a`.
-
-## Installing the GDNative in your project
-
-### Example project
-
-We provide a [demo project](demo/) in demo subfolder to help you to understand how to link the driver to your game project, and how to use it. 
+We provide releases in github repository. You can download `fmod.zip` from release tabs, unzip it, and copy it to
+`addons` folder of your project.  
 
 It does not contains :
-- built driver.
+- Libraries from FMOD company.
 
-It contains : 
+It contains :
+- built plugin
 - gdnlib and gdns
 - Fmod gdscript singleton
 - test scripts.
 
-### Copy addon folder
-
-Copy `addons/fmod` folder from [demo project](demo/) into your addons folder.
-
-### Copy built GDNative
-
-You have to copy the built GDNative driver in the correspoinding folder:  
-- windows: `res://addons/fmod/libs/windows/`
-- linux: `res://addons/fmod/libs/linux/`
-- osx: `res://addons/fmod/libs/osx/`
-- ios: `res://addons/fmod/libs/iOS/libGodotFmod.ios.release.arm64.a`
-- android: copy arm folders this way `res://addons/fmod/libs/android/arm64_v8a/`
-
 ### Add Fmod libraries to appropriate folder
 
 [Download the FMOD Studio API](https://www.fmod.com/download) (You need to create an account), if you have not done it yet.
-Then place fmod libraries in the appropriate folder, using `gdnlib` to know where:
+Then place fmod libraries (both `fmod` and `fmodstudio`) in the appropriate folder for each platform. A `CopyPast_Fmod_Libs_and_Gdnative_Here.txt` file
+should be present where you need to copy libraries.  
+Paths where you need to add shared libraries are:  
+- `res://addons/fmod/libs/android/arm64_v8a/`
+- `res://addons/fmod/libs/osx/`
+- `res://addons/fmod/libs/windows/`
+- `res://addons/fmod/libs/linux/`
+- `res://addons/fmod/libs/iOS/`
+
+You can also refer to `gdnlib` file in order to figure out what dependency is needed:
 
 ```
 [dependencies]
@@ -220,6 +98,8 @@ Windows.64=[ "res://addons/fmod/libs/windows/fmod.dll", "res://addons/fmod/libs/
 X11.64=[ "res://addons/fmod/libs/linux/libfmod.so", "res://addons/fmod/libs/linux/libfmodstudio.so" ]
 iOS.arm64=[ "res://addons/fmod/libs/iOS/libfmodstudio_iphoneos.a", "res://addons/fmod/libs/iOS/libfmod_iphoneos.a", "res://addons/fmod/libs/iOS/libgodot-cpp.ios.release.arm64.a" ]
 ```
+
+You should now be ready to go with Fmod and Godot !
 
 ### Fmod on android with GDNative
 

--- a/README.md
+++ b/README.md
@@ -433,13 +433,13 @@ func _ready():
 
 ### Muting all event
 
-You can mute all event using `muteAllEvents`. This will mute the master bus.
+You can mute all event using `mute_all_events`. This will mute the master bus.
 
 ```gdscript
 func _ready():
 	Fmod.set_software_format(0, Fmod.FMOD_SPEAKERMODE_STEREO, 0)
 	Fmod.init(1024, Fmod.FMOD_STUDIO_INIT_LIVEUPDATE, Fmod.FMOD_INIT_NORMAL)
-	Fmod.setSound3DSettings(1.0, 64.0, 1.0)
+	Fmod.set_sound_3d_settings(1.0, 64.0, 1.0)
 	
 	# load banks
 	Fmod.load_bank("res://Master.bank", Fmod.FMOD_STUDIO_LOAD_BANK_NORMAL)
@@ -476,7 +476,7 @@ func _ready():
 	# set up FMOD
 	Fmod.set_software_format(0, Fmod.FMOD_SPEAKERMODE_STEREO, 0)
 	Fmod.init(1024, Fmod.FMOD_STUDIO_INIT_LIVEUPDATE, Fmod.FMOD_INIT_NORMAL)
-	Fmod.setSound3DSettings(1/0, 64.0, 1.0)
+	Fmod.set_sound_3d_settings(1/0, 64.0, 1.0)
 	
 	# load banks
 	Fmod.load_bank("res://Master.bank", Fmod.FMOD_STUDIO_LOAD_BANK_NORMAL)
@@ -489,7 +489,7 @@ func _ready():
 	# play some events
 	Fmod.play_one_shot("event:/Music/Level 02", self)
 	var my_music_event = Fmod.create_event_instance("event:/Music/Level 01")
-	Fmod.startEvent(my_music_event)
+	Fmod.start_event(my_music_event)
 	var t = Timer.new()
 	t.set_wait_time(3)
 	t.set_one_shot(true)
@@ -510,7 +510,7 @@ func _ready():
 
 By default, FMOD will use the primary audio output device as determined by the operating system. This can be changed at runtime, ideally through your game's Options Menu.
 
-Here, `getAvailableDrivers()` returns an Array which contains a Dictionary for every audio driver found. Each Dictionary contains fields such as the name, sample rate
+Here, `get_available_drivers()` returns an Array which contains a Dictionary for every audio driver found. Each Dictionary contains fields such as the name, sample rate
 and speaker config of the respective driver. Most importantly, it contains the id for that driver.
 
  ```gdscript
@@ -536,7 +536,7 @@ Fmod.get_dsp_num_buffers()
 
 ### Profiling & querying performance data
 
-`getPerformanceData` returns an object which contains current performance stats for CPU, Memory and File Streaming usage of both FMOD Studio and the Core System.
+`get_performance_data` returns an object which contains current performance stats for CPU, Memory and File Streaming usage of both FMOD Studio and the Core System.
 
 ```gdscript
 # called every frame

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -1,0 +1,119 @@
+# Compiling from sources
+
+## Typical Project structure
+
+```
+└── Project root
+    ├── libs
+    |   └── fmod
+    |       └── {platform}
+    |           └── specific platform fmod api goes here
+    ├── godot-cpp (gdnative bindings, consider using a git submodule)
+    └── fmod-gdnative (this repo, consider using it as a submodule of you GDNatives repo)
+        ├── CMakeLists.txt (Here for CLion)
+        ├── LICENSE
+        ├── README.md
+        ├── SConstruct (here to build on Windows, Linux, OSX and IOS
+        └── src
+```
+
+If you look at [Sconstruct](SConstruct) script, you'll see that it refers to libraries that are in path relatives to
+parent folder. This is because Utopia-Rise team chose to make this repo integrated to a unique repository, storing all
+the GDNative for our project.
+
+So, you are supposed to put fmod libraries under `libs/fmod/{platform}`, according to the platforms you want to support.
+
+Otherwise, you can use [our example project](https://github.com/utopia-rise/GDNative-example-repo), which already contains the appropriate structure.
+
+Feel free to modify SConstruct according to your project structure.
+
+`CMakeLists` is here for CLion ide, as we are used to JetBrains tools. Unfortunately, CLion does not currently support
+Sconstruct.
+
+## Building Fmod plugin
+
+### Building GDNative API bindings
+
+To Build GDNative bindings you can follow [this tutorial from godot official documentation](https://docs.godotengine.org/en/3.1/tutorials/plugins/gdnative/gdnative-cpp-example.html#building-the-c-bindings).
+If you want to regenerate api you can add the following argument to your building command :
+```
+godotbinpath="path to your godot binary"
+```
+When you're done with that part you should have `libgodot-cpp.<platform>.<target>.<bits|android_arch|ios_arch>.<a|lib>` in godot-cpp/bin` folder.
+
+#### iOS
+
+To build bindings for iOS, execute:
+```
+scons platform=ios generate_bindings=True ios_arch=armv7/arm64 target=release
+```
+
+#### Android
+
+To build bindings for android, we provide our [godot-cpp](https://github.com/utopia-rise/godot-cpp) version.
+Checkout `utopia-3.2` branch. This is also provided with our [GDNative example project](https://github.com/utopia-rise/GDNative-example-repo).  
+First, you should set `ANDROID_NDK_ROOT` environment variable by typing :
+```
+export ANDROID_NDK_ROOT="pathToYourAndroidNDK"
+```  
+To build on Android, you should type :
+```
+scons platform=android generate_bindings=True android_arch=armv7/arm64v8 target=release
+```
+
+### Building the GDNative plugin
+
+[Download the FMOD Studio API](https://www.fmod.com/download) (You need to create an account) and place it in the
+appropriate platform folder into lib folder (see project structure).
+
+For each platforms, if your project structure is different from the one proposed here, you can overload `cpp_bindings_dir`
+and `headers_dir` parameters.
+
+To load fmod dynamic libraries on app or engine loading, fmod GDNative will look in subfolder `libs` by default, as in OSX
+part. you can overload this relative path adding this parameter to the command `fmod_lib_dir="path to fmod dll"`.
+
+#### OSX
+
+To build the GDNative for OSX, you should use this command in `fmod-gdnative` folder :
+
+```
+scons platform=osx target=release bits=64
+```
+
+This will generate `libGodotFmod.osx.release.64.dylib` in `fmod-gdnative/bin` folder.
+
+
+#### Linux
+
+To build the GDNative for Linux, you should use this command in `fmod-gdnative` folder :
+```
+scons platform=linux use_llvm=yes target=release bits=64
+```
+This will generate a `libGodotFmod.linux.release.64.so` in `fmod-gdnative/bin` folder.
+
+#### Windows
+
+To build the GDNative for Windows, you should use this command in `fmod-gdnative` folder :
+```
+scons platform=windows target=release bits=64
+```
+This will generate `libGodotFmod.windows.release.64.dll` in `fmod-gdnative/bin` folder.
+
+#### Android
+
+To build the GDNative for Android, we currently use NDKBuild. So you should use this command in `fmod-gdnative` folder :
+```
+$ANDROID_NDK_ROOT/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=Android.mk  APP_PLATFORM=android-21
+```
+This will generate `libGodotFmod.android.<target>.<android_arch>.so` for each supported architectures in `libs` folder.
+
+#### iOS
+
+To build the GDNative for iOS, you should use this command in `fmod-gdnative` folder :
+```
+scons platform=ios target=release ios-arch=armv7/arm64
+```
+This will generate `libGodotFmod.ios.release.arm64.a` in `fmod-gdnative/bin` folder.
+
+Those libraries are statics, so you need to add fmod static librairies and godot-cpp static library for ios in your
+project, with `libGodotFmod.ios.release.arm64.a`.


### PR DESCRIPTION
This splits compiling documentation section in another markdown file.  
This should make readme more straightforward regarding how to install plugin.  
This resolves #80 