### PR TITLE
Port all_builds.yml to be compatible to GDExtension

### DIFF
--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -1,7 +1,7 @@
 name: 🌈 All Builds
 on:
   push:
-    branches: [ master, godot-4.0-adaption-actions-2 ]
+    branches: [ master, godot-4.0-adaption ]
     tags:
       - "v*"
   pull_request:
@@ -43,6 +43,20 @@ jobs:
             artifact-extension: framework
             fmod-executable: fmodstudioapi20203osx.dmg
 
+          - name: Android Compilation
+            os: "ubuntu-20.04"
+            artifact-name: android
+            artifact-extension: so
+            fmod-executable: fmodstudioapi20203android.tar.gz
+            flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
+
+          - name: iOS Compilation
+            os: "macos-11"
+            artifact-name: ios
+            artifact-extension: dylib
+            fmod-executable: fmodstudioapi20203ios.dmg
+            flags: arch=arm64
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -78,7 +92,7 @@ jobs:
           mv api/ windows
           cd ../../
 
-      - name : Installing FMOD on Linux
+      - name : Installing FMOD on Linux & Android
         if: runner.os == 'Linux'
         run: |
           cd ..
@@ -86,10 +100,10 @@ jobs:
           mkdir fmod && cd fmod
           python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} ${{matrix.artifact-name}} ${{env.FMOD_VERSION}}
           tar -xvf ${{matrix.fmod-executable}}
-          mv fmodstudioapi${{env.FMOD_VERSION}}linux/api linux
+          mv fmodstudioapi${{env.FMOD_VERSION}}${{matrix.artifact-name}}/api ${{matrix.artifact-name}}
           cd ../../
 
-      - name : Installing FMOD on MacOS
+      - name : Installing FMOD on MacOS & iOS
         if: runner.os == 'MacOS'
         run: |
           cd ..
@@ -97,13 +111,14 @@ jobs:
           mkdir fmod && cd fmod
           python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} ${{matrix.artifact-name}} ${{env.FMOD_VERSION}}
           hdiutil attach ${{matrix.fmod-executable}}
-          cp -r "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api" osx
+          [[ ${{matrix.artifact-name}} = "macos" ]] && cp -r "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api" osx
+          [[ ${{matrix.artifact-name}} = "ios" ]] && cp -r "/Volumes/FMOD Programmers API iOS/FMOD Programmers API/api" ios
           cd ../../
 
       - name: Compilation
         run: |
           cd ../${{env.PROJECT_FOLDER}}
-          scons platform=${{ matrix.artifact-name }} target=${{ env.TARGET }} target_path=${{ env.TARGET_PATH }} target_name=${{ env.TARGET_NAME }}
+          scons platform=${{ matrix.artifact-name }} target=${{ env.TARGET }} target_path=${{ env.TARGET_PATH }} target_name=${{ env.TARGET_NAME }} -j6 ${{ matrix.flags }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -1,7 +1,7 @@
 name: 🌈 All Builds
 on:
   push:
-    branches: [ master, godot-4.0-adaption ]
+    branches: [ master, godot-4.x ]
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -1,7 +1,7 @@
 name: 🌈 All Builds
 on:
   push:
-    branches: [ master ]
+    branches: [ master, godot-4.0-adaption-actions-2 ]
     tags:
       - "v*"
   pull_request:
@@ -10,27 +10,49 @@ on:
 # Global Settings
 env:
   PROJECT_FOLDER: fmod-gdnative
+  TARGET_PATH: demo/addons/fmod/bin/
+  TARGET_NAME: libGodotFmod
   TARGET: release
   GODOT_VERSION: 3.4
-  UTOPIA_GODOT_CPP_REF: godot-3.4-stable
   FMOD_VERSION: 20203
 
 jobs:
-  windows-compilation:
-    name: Windows Compilation
-    runs-on: "windows-latest"
-    env:
-      FMOD_EXECUTABLE: fmodstudioapi20203win-installer.exe
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows Compilation
+            os: "windows-latest"
+            artifact-name: windows
+            artifact-extension: dll
+            additional-python-packages: pywin32
+            fmod-executable: fmodstudioapi20203win-installer.exe
+
+          - name: Ubuntu Compilation
+            os: "ubuntu-20.04"
+            artifact-name: linux
+            artifact-extension: so
+            fmod-executable: fmodstudioapi20203linux.tar.gz
+
+          - name: MacOS Compilation
+            os: "macos-11"
+            artifact-name: macos
+            artifact-extension: framework
+            fmod-executable: fmodstudioapi20203osx.dmg
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          submodules: recursive
           lfs: true
+          submodules: recursive
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -41,431 +63,51 @@ jobs:
       - name: Configuring Python packages
         run: |
           python -c "import sys; print(sys.version)"
-          python -m pip install scons pywin32 requests
+          python -m pip install scons requests ${{ matrix.additional-python-packages }}
           python --version
           scons --version
 
-      - name : Installing FMOD
+      - name : Installing FMOD on Windows
+        if: runner.os == 'Windows'
         run: |
           cd ..
           New-Item -ItemType directory -Path libs; cd libs
           New-Item -ItemType directory -Path fmod; cd fmod
-          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} windows ${{env.FMOD_VERSION}}
-          7z x ${{env.FMOD_EXECUTABLE}}
+          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} ${{matrix.artifact-name}} ${{env.FMOD_VERSION}}
+          7z x ${{matrix.fmod-executable}}
           mv api/ windows
           cd ../../
 
-      # The `godot-cpp`-repository is currently cloned inside of the project folder.
-      # This is a limitation of the checkout action and will be fixed in PR#388...
-      # For now we'll have to copy the `godot-cpp`-repository ourselves!
-      - name: Cloning godot-cpp
-        uses: actions/checkout@v2
-        with:
-          repository: godotengine/godot-cpp
-          path: godot-cpp
-          ref: ${{env.UTOPIA_GODOT_CPP_REF}}
-          submodules: recursive
-
-      - name: Compilation
-        run: |
-          Copy-Item -Path "./godot-cpp/" -Destination "../godot-cpp/" -Recurse
-          cd ../godot-cpp
-          scons platform=windows bits=64 target=${{env.TARGET}} generate_bindings=yes -j4
-          cd ../${{env.PROJECT_FOLDER}}
-          scons platform=windows target=${{env.TARGET}}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows
-          path: bin/libGodotFmod.windows.release.64.dll
-
-  linux-compilation:
-    name: Linux Compilation
-    runs-on: "ubuntu-20.04"
-    env:
-      FMOD_EXECUTABLE: fmodstudioapi20203linux.tar.gz
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          lfs: true
-
-      # Install all packages (except scons)
-      - name: Configure dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
-
-      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
-          # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
-
-      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
-      - name: Configuring Python packages
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons requests
-          python --version
-          scons --version
-
-      - name : Installing FMOD
+      - name : Installing FMOD on Linux
+        if: runner.os == 'Linux'
         run: |
           cd ..
           mkdir libs && cd libs
           mkdir fmod && cd fmod
-          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} linux ${{env.FMOD_VERSION}}
-          tar -xvf ${{env.FMOD_EXECUTABLE}}
-          mv fmodstudioapi20203linux/api linux
+          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} ${{matrix.artifact-name}} ${{env.FMOD_VERSION}}
+          tar -xvf ${{matrix.fmod-executable}}
+          mv fmodstudioapi${{env.FMOD_VERSION}}linux/api linux
           cd ../../
 
-      # The `godot-cpp`-repository is currently cloned inside of the project folder.
-      # This is a limitation of the checkout action and will be fixed in PR#388...
-      # For now we'll have to copy the `godot-cpp`-repository ourselves!
-      - name: Cloning godot-cpp
-        uses: actions/checkout@v2
-        with:
-          repository: godotengine/godot-cpp
-          path: godot-cpp
-          ref: ${{env.UTOPIA_GODOT_CPP_REF}}
-          submodules: recursive
-
-      - name: Compilation
-        run: |
-          cp -r godot-cpp ../godot-cpp
-          cd ../godot-cpp
-          scons platform=linux bits=64 target=${{env.TARGET}} generate_bindings=yes -j4
-          cd ../${{env.PROJECT_FOLDER}}
-          scons platform=linux target=${{env.TARGET}}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux
-          path: bin/libGodotFmod.linux.release.64.so
-
-  macos-compilation:
-    name: MacOS Compilation
-    # Use macos-11 since macos-latest still points to version 10.15, which doesn't support arm64
-    runs-on: "macos-11"
-    env:
-      FMOD_EXECUTABLE: fmodstudioapi20203osx.dmg
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          lfs: true
-
-      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
-          # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
-
-      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
-      - name: Configuring Python packages
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons requests
-          python --version
-          scons --version
-
-      - name : Installing FMOD
+      - name : Installing FMOD on MacOS
+        if: runner.os == 'MacOS'
         run: |
           cd ..
           mkdir libs && cd libs
           mkdir fmod && cd fmod
-          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} osx ${{env.FMOD_VERSION}}
-          hdiutil attach ${{env.FMOD_EXECUTABLE}}
+          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} ${{matrix.artifact-name}} ${{env.FMOD_VERSION}}
+          hdiutil attach ${{matrix.fmod-executable}}
           cp -r "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api" osx
           cd ../../
 
-      # The `godot-cpp`-repository is currently cloned inside of the project folder.
-      # This is a limitation of the checkout action and will be fixed in PR#388...
-      # For now we'll have to copy the `godot-cpp`-repository ourselves!
-      - name: Cloning godot-cpp
-        uses: actions/checkout@v2
-        with:
-          repository: godotengine/godot-cpp
-          path: godot-cpp
-          ref: ${{env.UTOPIA_GODOT_CPP_REF}}
-          submodules: recursive
-
       - name: Compilation
         run: |
-          cp -r godot-cpp ../godot-cpp
-          cd ../godot-cpp
-          scons platform=osx bits=64 target=${{env.TARGET}} generate_bindings=yes -j4
           cd ../${{env.PROJECT_FOLDER}}
-          scons platform=osx target=${{env.TARGET}}
+          scons platform=${{ matrix.artifact-name }} target=${{ env.TARGET }} target_path=${{ env.TARGET_PATH }} target_name=${{ env.TARGET_NAME }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: osx
-          path: bin/libGodotFmod.osx.release.64.dylib
-
-  android-compilation:
-    name: Android Compilation
-    runs-on: "ubuntu-20.04"
-    env:
-      FMOD_EXECUTABLE: fmodstudioapi20203android.tar.gz
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2 
-        with:
-            submodules: recursive
-            lfs: true
-
-      - name: Set up Java 8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-
-      # Use python 3.x release (works cross platform)
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
-          # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
-
-      - name: Configuring Python packages
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons requests
-          python --version
-          scons --version
-
-      - name : Installing FMOD
-        run: |
-          cd ..
-          mkdir libs && cd libs
-          mkdir fmod && cd fmod
-          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} android ${{env.FMOD_VERSION}}
-          tar -xvf ${{env.FMOD_EXECUTABLE}}
-          mv fmodstudioapi20203android/api android
-          cd ../../
-
-      # The `godot-cpp`-repository is currently cloned inside of the project folder.
-      # This is a limitation of the checkout action and will be fixed in PR#388...
-      # For now we'll have to copy the `godot-cpp`-repository ourselves!
-      - name: Cloning godot-cpp
-        uses: actions/checkout@v2
-        with:
-          repository: godotengine/godot-cpp
-          path: godot-cpp
-          ref: ${{env.UTOPIA_GODOT_CPP_REF}}
-          submodules: recursive
-
-      - name: Compilation
-        env:
-          ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/21.4.7075529
-        run: |
-          cp -r godot-cpp ../godot-cpp
-          cd ../godot-cpp
-          scons platform=android bits=64 android_arch=armv7 target=${{env.TARGET}} generate_bindings=yes -j4
-          scons platform=android bits=64 android_arch=arm64v8 target=${{env.TARGET}} generate_bindings=yes -j4
-          cd ../${{env.PROJECT_FOLDER}}
-          $ANDROID_NDK_ROOT/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=Android.mk APP_PLATFORM=android-21 NDK_LIBS_OUT=bin/
-      
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: android
-          path: |
-            bin/armeabi-v7a/libGodotFmod.android.release.armeabi-v7a.so
-            bin/arm64-v8a/libGodotFmod.android.release.arm64-v8a.so
-
-  ios-compilation:
-    name: iOS Compilation
-    runs-on: "macos-latest"
-    env:
-      FMOD_EXECUTABLE: fmodstudioapi20203ios.dmg
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          lfs: true
-
-      # Use python 3.x release (works cross platform)
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
-          # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
-
-      # You can test your matrix by printing the current Python version
-      - name: Configuring Python packages
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons requests
-          python --version
-          scons --version
-
-      - name : Installing FMOD
-        run: |
-          cd ..
-          mkdir libs && cd libs
-          mkdir fmod && cd fmod
-          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} ios ${{env.FMOD_VERSION}}
-          hdiutil attach ${{env.FMOD_EXECUTABLE}}
-          cp -r "/Volumes/FMOD Programmers API iOS/FMOD Programmers API/api" ios
-          cd ../../
-
-      # The `godot-cpp`-repository is currently cloned inside of the project folder.
-      # This is a limitation of the checkout action and will be fixed in PR#388...
-      # For now we'll have to copy the `godot-cpp`-repository ourselves!
-      - name: Cloning godot-cpp
-        uses: actions/checkout@v2
-        with:
-          repository: godotengine/godot-cpp
-          path: godot-cpp
-          ref: ${{env.UTOPIA_GODOT_CPP_REF}}
-          submodules: recursive
-
-      - name: Compilation
-        run: |
-          cp -r "godot-cpp" "../godot-cpp"
-          cd ../godot-cpp
-          scons platform=ios ios_arch=arm64 bits=64 target=${{env.TARGET}} generate_bindings=yes -j4
-          cd ../${{env.PROJECT_FOLDER}}
-          scons platform=ios ios_arch=arm64 target=${{env.TARGET}}
-          cp "../godot-cpp/bin/libgodot-cpp.ios.release.arm64.a" "bin/libgodot-cpp.ios.release.arm64.a"
-
-      # Unfortunately the `upload-artefact@v2`-action doesn't allow the use of . or ..
-      # So we have to use the full path to the compiled godot-cpp library here.
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ios
-          path: |
-            bin/libGodotFmod.ios.release.arm64.a
-            bin/libgodot-cpp.ios.release.arm64.a
-
-  test:
-    name: GUT Test
-    runs-on: macos-latest
-    needs: [macos-compilation]
-    env:
-      FMOD_EXECUTABLE: fmodstudioapi20203osx.dmg
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          lfs: true
-
-      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
-          # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
-
-      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
-      - name: Configuring Python packages
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons requests
-          python --version
-          scons --version
-
-      - name : Installing FMOD
-        run: |
-          cd ..
-          mkdir libs && cd libs
-          mkdir fmod && cd fmod
-          python ../../${{env.PROJECT_FOLDER}}/get_fmod.py ${{secrets.FMODUSER}} ${{secrets.FMODPASS}} osx ${{env.FMOD_VERSION}}
-          hdiutil attach ${{env.FMOD_EXECUTABLE}}
-          cp -r "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api" osx
-          cd ../../
-
-      - name: Download Godot Engine
-        run: |
-          wget https://downloads.tuxfamily.org/godotengine/${{env.GODOT_VERSION}}/Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
-          unzip Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
-          rm Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
-      - name: Download OSX binary
-        uses: actions/download-artifact@v2
-        with:
-          name: osx
-
-      - name: Run Tests
-        run: |
-          mkdir -p demo/addons/fmod/libs/osx/
-          cp libGodotFmod.osx.release.64.dylib demo/addons/fmod/libs/osx/
-          cp "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api/core/lib/libfmod.dylib" demo/addons/fmod/libs/osx/
-          cp "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api/studio/lib/libfmodstudio.dylib" demo/addons/fmod/libs/osx/
-          cd demo
-          chmod +x run_tests.sh
-          ./run_tests.sh ../Godot.app/Contents/MacOS/Godot
-
-  release:
-    name: Release
-    runs-on: "ubuntu-20.04"
-    needs: [windows-compilation, linux-compilation, macos-compilation, ios-compilation, android-compilation, test]
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Changes in this Release
-            - First Change
-            - Second Change
-          draft: false
-          prerelease: false
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          lfs: true
-
-      - name: Download Artefacts
-        uses: actions/download-artifact@v2
-
-      - name: Copy Libraries to Libs Folder
-        run: |
-          cp windows/libGodotFmod.windows.release.64.dll demo/addons/fmod/libs/windows/
-          cp linux/libGodotFmod.linux.release.64.so demo/addons/fmod/libs/linux/
-          cp osx/libGodotFmod.osx.release.64.dylib demo/addons/fmod/libs/osx/
-          cp android/armeabi-v7a/libGodotFmod.android.release.armeabi-v7a.so demo/addons/fmod/libs/android/armeabi_v7a/
-          cp android/arm64-v8a/libGodotFmod.android.release.arm64-v8a.so demo/addons/fmod/libs/android/arm64_v8a/
-          cp ios/libGodotFmod.ios.release.arm64.a demo/addons/fmod/libs/iOS/
-          cp ios/libgodot-cpp.ios.release.arm64.a demo/addons/fmod/libs/iOS/
-          cd demo/addons/
-          zip -r fmod.zip fmod/
-
-      - name: Upload Release Assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: /home/runner/work/fmod-gdnative/fmod-gdnative/demo/addons/fmod.zip
-          asset_name: fmod.zip
-          asset_content_type: application/zip
+          name: ${{ matrix.artifact-name }}
+          path: ${{ env.TARGET_PATH }}*.${{ matrix.artifact-extension }}
+          if-no-files-found: error

--- a/SConstruct
+++ b/SConstruct
@@ -35,12 +35,14 @@ if env["platform"] == "macos":
     env.Append(CPPPATH=[env['fmod_lib_dir'] + 'osx/core/inc/', env['fmod_lib_dir'] + 'osx/studio/inc/'])
     env.Append(LIBS=[libfmod, libfmodstudio])
     env.Append(LIBPATH=[env['fmod_lib_dir'] + 'osx/core/lib/', env['fmod_lib_dir'] + 'osx/studio/lib/'])
+
 elif env["platform"] == "linux":
     libfmod = 'libfmod%s.so'% lfix
     libfmodstudio = 'libfmodstudio%s.so'% lfix
     env.Append(CPPPATH=[env['fmod_lib_dir'] + 'linux/core/inc/', env['fmod_lib_dir'] + 'linux/studio/inc/'])
     env.Append(LIBS=[libfmod, libfmodstudio])
     env.Append(LIBPATH=[env['fmod_lib_dir'] + 'linux/core/lib/' + env["arch_suffix"], env['fmod_lib_dir'] + 'linux/studio/lib/' + env["arch_suffix"]])
+
 elif env["platform"] == "windows":
     libfmod = 'fmod%s_vc'% lfix
     libfmodstudio = 'fmodstudio%s_vc'% lfix
@@ -52,6 +54,27 @@ elif env["platform"] == "windows":
     env.Append(CPPPATH=[env['fmod_lib_dir'] + 'windows/core/inc/', env['fmod_lib_dir'] + 'windows/studio/inc/'])
     env.Append(LIBS=[libfmod, libfmodstudio])
     env.Append(LIBPATH=[env['fmod_lib_dir'] + 'windows/core/lib/' + arch_suffix_override, env['fmod_lib_dir'] + 'windows/studio/lib/' + arch_suffix_override])
+
+elif env["platform"] == "ios":
+    libfmod = 'libfmod%s_iphoneos.a' % lfix
+    libfmodstudio = 'libfmodstudio%s_iphoneos.a' % lfix
+    env.Append(CPPPATH=[env['fmod_lib_dir'] + 'ios/core/inc/', env['fmod_lib_dir'] + 'ios/studio/inc/'])
+    env.Append(LIBS=[libfmod, libfmodstudio])
+    env.Append(LIBPATH=[env['fmod_lib_dir'] + 'ios/core/lib/', env['fmod_lib_dir'] + 'ios/studio/lib/'])
+
+elif env["platform"] == "android":
+    libfmod = 'libfmod%s.so' % lfix
+    libfmodstudio = 'libfmodstudio%s.so' % lfix
+    fmod_info_table = {
+        "armv7": "armeabi-v7a",
+        "arm64": "arm64-v8a",
+        "x86": "x86",
+        "x86_64": "x86_64"
+    }
+    arch_dir = fmod_info_table[env["arch_suffix"]]
+    env.Append(CPPPATH=[env['fmod_lib_dir'] + 'android/core/inc/', env['fmod_lib_dir'] + 'android/studio/inc/'])
+    env.Append(LIBS=[libfmod, libfmodstudio])
+    env.Append(LIBPATH=[env['fmod_lib_dir'] + 'android/core/lib/' + arch_dir, env['fmod_lib_dir'] + 'android/studio/lib/' + arch_dir])
 
 if env["platform"] == "macos":
     target = "{}.framework/{}.{}.{}".format(

--- a/get_fmod.py
+++ b/get_fmod.py
@@ -14,7 +14,7 @@ if platform == 'linux':
     # linux
     filename = f'fmodstudioapi{fmod_version}linux.tar.gz'
     downloadlink = f'https://www.fmod.com/api-get-download-link?path=files/fmodstudio/api/Linux/&filename=fmodstudioapi{fmod_version}linux.tar.gz&user='
-elif platform == 'osx':
+elif platform == 'macos':
     # OS X
     filename = f'fmodstudioapi{fmod_version}osx.dmg'
     downloadlink = f'https://www.fmod.com/api-get-download-link?path=files/fmodstudio/api/Mac/&filename=fmodstudioapi{fmod_version}mac-installer.dmg&user='

--- a/src/callback/file_callbacks.h
+++ b/src/callback/file_callbacks.h
@@ -7,6 +7,7 @@
 #include "../helpers/containers.h"
 #include <thread>
 #include <condition_variable>
+#include <cstring> // This include is required for both Linux and MacOS targets as they don't include the necessary headers for 'memcpy' by default
 
 namespace Callbacks {
     struct GodotFileHandle {


### PR DESCRIPTION
@bitbrain 

This ports Github Actions compilation for all platforms to be compatible with the new GDExtension.
I'm still having some issues with iOS, but I imagine it's related to FMOD having to update their binaries (?).

I'll see if I can port the automatic GUT and release stage as well at some point.

EDIT: I propose to merge this branch as soon as possible into godot-4.0-adaption such that we can detect any new compilation bugs and errors immediately and effortlessly.