### PR TITLE
Update compatbility matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,39 +29,21 @@ This project uses github actions to continuously deploy released drivers. If you
 can compile from sources by looking to [compile from sources section](./docs/COMPILING.md).  
 This project uses [SEMVER](https://semver.org/).
 
-#### OS Compatibility matrix :
+#### OS Compatibility:
 
-| Driver Version | Windows | Linux | OSX | Android | iOS |
-|----------------|---------|-------|-----|---------|-----|
-|      0.0.0     |    X    |   X   |  X  |         |     |
-|      1.0.0     |    X    |   X   |  X  |    X    |  X  |
-|      2.0.0     |    X    |   X   |  X  |    X    |  X  |
-|      2.0.1     |    X    |   X   |  X  |    X    |  X  |
-|      2.0.2     |    X    |   X   |  X  |    X    |  X  |
-|      3.x.x     |    X    |   X   |  X  |    X    |  X  |
+This plugin is compatible with Windows, Linux, OSX, Android and iOS. No WASM/HTML 5 support is available for now.
 
 #### Godot compatibility matrix
 
-| Driver Version | Godot 3.0 | Godot 3.1 | Godot 3.2 | Godot 3.3 | Godot 3.4 |
-|----------------|-----------|-----------|-----------|-----------|-----------|
-|      0.0.0     |           |      X    |           |           |           |
-|      1.0.0     |           |      X    |           |           |           |
-|      2.0.0     |           |      X    |           |           |           |
-|      2.0.1     |           |      X    |           |           |           |
-|      2.0.2     |           |      X    |           |           |           |
-|      3.x.x     |           |      X    |     X     |     X     |     X     |
+This plugin should run on any 3.1+ version of Godot (Godot 4 not supported yet and will break compatibility when it comes). 
+New releases are build and tested against recent version of Godot but no breaking changes should happen.
 
 #### Fmod compatibility matrix
 
-| Driver Version | 1.10.13 | 2.00.XX | 2.0X.XX |
-|----------------|---------|---------|---------|
-|      0.0.0     |    X    |         |         |
-|      1.0.0     |    X    |         |         |
-|      2.0.0     |    X    |         |         |
-|      2.0.1     |    X    |         |         |
-|      2.0.2     |    X    |         |         |
-|      3.0.0     |         |    X    |         |
-|      3.x.x     |         |         |    X    |
+| Driver Version | Api Version |
+|----------------|-------------|
+|      3.0.x     |   2.00.XX   | 
+|      3.1+      |   2.02.XX   |
 
 ## Installing the plugin in your project
 


### PR DESCRIPTION
Solve #115 
I remove most of the compatibility matrixes as the plugin has been running on all platforms for a long time so it doesn't seem necessary to keep noted that version 0.0 doesn't run on mobile.

Regarding the Godot version, the GDNative API has been stable I have never needed to be encountered any issue testing the plugin on older versions (but I didn't try running our latest release on Godot 3.1, so I might be wrong)

Regarding drivers compatibility, it's hard to track down which APi version was used when. It seems we started using 2.00.x with the 3.0 and 2.02.x with 3.1 and according to the issue 3.1.1 doesn't work with 2.01.x, so I'll just keep those 2 entries.