### PR TITLE
fix: Fmod event emitter now works as in 3.x and code has been simplified

### DIFF
--- a/demo/high_level/ChangeColor.gd
+++ b/demo/high_level/ChangeColor.gd
@@ -1,0 +1,25 @@
+extends Area2D
+
+var event: FmodEvent = null
+var icon: Sprite2D
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	body_entered.connect(enter)
+	body_exited.connect(leave)
+	$FmodEventEmitter2D.paused = true
+
+# warning-ignore:unused_argument
+func enter(_area):
+	print("enter")
+	
+	$FmodEventEmitter2D.paused = false
+	
+# warning-ignore:unused_argument
+func leave(_area):
+	print("leave")
+	$FmodEventEmitter2D.paused = true
+
+# warning-ignore:unused_argument
+func change_color(_dict: Dictionary):
+	$icon.self_modulate = Color(randf_range(0,1), randf_range(0,1), randf_range(0,1), 1)

--- a/demo/high_level/Emitter.gd
+++ b/demo/high_level/Emitter.gd
@@ -1,0 +1,15 @@
+extends FmodEventEmitter2D
+
+var isPlaying: bool = true
+
+func _process(_delta):
+	if Input.is_action_just_pressed("space"):
+		isPlaying = !isPlaying
+		if(isPlaying):
+			print("Mower playing")
+			paused = false
+		else:
+			print("Mower paused")
+			paused = true
+	elif Input.is_action_just_pressed("kill_event"):
+		self.queue_free()

--- a/demo/high_level/FmodNodesTest.gd
+++ b/demo/high_level/FmodNodesTest.gd
@@ -1,0 +1,11 @@
+extends Node
+
+# Called when the node enters the scene tree for the first time.
+func _enter_tree():
+	
+	# set up FMOD
+	FmodServer.set_software_format(0, FmodServer.FMOD_SPEAKERMODE_STEREO, 0)
+	FmodServer.init(1024, FmodServer.FMOD_STUDIO_INIT_LIVEUPDATE, FmodServer.FMOD_INIT_NORMAL)
+	FmodServer.set_sound_3D_settings(1.0, 32.0, 1.0)
+	
+	print("Fmod initialised.")

--- a/demo/high_level/FmodNodesTest.tscn
+++ b/demo/high_level/FmodNodesTest.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://low_level/FmodTest.gd" id="1_7eafu"]
 [ext_resource type="Texture2D" uid="uid://dichdnwxg2opa" path="res://icon.png" id="2_llv2n"]
-[ext_resource type="Script" path="res://low_level/Listener.gd" id="4_2l5m5"]
+[ext_resource type="Script" path="res://high_level/Kinematic.gd" id="3_dlbku"]
 [ext_resource type="Script" path="res://low_level/EnterAndLeave.gd" id="5_jxvuy"]
 [ext_resource type="Script" path="res://low_level/ChangeColor.gd" id="6_ftrrq"]
 [ext_resource type="Script" path="res://low_level/EnterandLeave2.gd" id="7_c28gt"]
@@ -50,7 +50,9 @@ texture = ExtResource("2_llv2n")
 
 [node name="Listener" type="CharacterBody2D" parent="."]
 position = Vector2(500, 150)
-script = ExtResource("4_2l5m5")
+script = ExtResource("3_dlbku")
+
+[node name="FmodListener2D" type="FmodListener2D" parent="Listener"]
 
 [node name="icon" type="Sprite2D" parent="Listener"]
 position = Vector2(1.89996, 4.12415)

--- a/demo/high_level/FmodNodesTest.tscn
+++ b/demo/high_level/FmodNodesTest.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=10 format=3 uid="uid://dl6g18ybwc83t"]
+[gd_scene load_steps=11 format=3 uid="uid://dl6g18ybwc83t"]
 
-[ext_resource type="Script" path="res://low_level/FmodTest.gd" id="1_7eafu"]
+[ext_resource type="Script" path="res://high_level/FmodNodesTest.gd" id="1_apdyc"]
+[ext_resource type="Script" path="res://high_level/Emitter.gd" id="2_5cntr"]
 [ext_resource type="Texture2D" uid="uid://dichdnwxg2opa" path="res://icon.png" id="2_llv2n"]
 [ext_resource type="Script" path="res://high_level/Kinematic.gd" id="3_dlbku"]
+[ext_resource type="Script" path="res://high_level/ChangeColor.gd" id="5_5p5kb"]
 [ext_resource type="Script" path="res://low_level/EnterAndLeave.gd" id="5_jxvuy"]
-[ext_resource type="Script" path="res://low_level/ChangeColor.gd" id="6_ftrrq"]
 [ext_resource type="Script" path="res://low_level/EnterandLeave2.gd" id="7_c28gt"]
 
 [sub_resource type="RectangleShape2D" id="1"]
@@ -17,14 +18,16 @@ size = Vector2(288.124, 291.966)
 [sub_resource type="RectangleShape2D" id="3"]
 size = Vector2(289.938, 284.96)
 
-[node name="FmodNodesTest" type="Node2D"]
-position = Vector2(0, -3)
-script = ExtResource("1_7eafu")
+[node name="FmodNodesTest" type="Node"]
+script = ExtResource("1_apdyc")
 
-[node name="Node2D" type="Node2D" parent="."]
+[node name="FmodBankLoader" type="FmodBankLoader" parent="."]
+bank_paths = ["res://assets/Banks/Master.strings.bank", "res://assets/Banks/Master.bank", "res://assets/Banks/Music.bank", "res://assets/Banks/Vehicles.bank"]
+
+[node name="Node2D" type="Node2D" parent="FmodBankLoader"]
 position = Vector2(500, 500)
 
-[node name="Emitter" type="FmodEventEmitter2D" parent="Node2D"]
+[node name="Emitter" type="FmodEventEmitter2D" parent="FmodBankLoader/Node2D"]
 event_name = "event:/Vehicles/Car Engine"
 autoplay = true
 parameters = {
@@ -33,8 +36,9 @@ parameters = {
 volume = 2.0
 self_modulate = Color(0.988235, 0, 0, 1)
 position = Vector2(-3.05176e-05, 0)
+script = ExtResource("2_5cntr")
 
-[node name="Label" type="Label" parent="Node2D"]
+[node name="Label" type="Label" parent="FmodBankLoader/Node2D"]
 anchors_preset = 4
 anchor_top = 0.5
 anchor_bottom = 0.5
@@ -43,26 +47,26 @@ size_flags_stretch_ratio = 0.0
 text = "Press Space to pause/unpause
 Come closer to hear it"
 
-[node name="Sprite" type="Sprite2D" parent="Node2D"]
+[node name="Sprite" type="Sprite2D" parent="FmodBankLoader/Node2D"]
 self_modulate = Color(0.988235, 0, 0, 1)
 position = Vector2(-3.05176e-05, 0)
 texture = ExtResource("2_llv2n")
 
-[node name="Listener" type="CharacterBody2D" parent="."]
+[node name="Listener" type="CharacterBody2D" parent="FmodBankLoader"]
 position = Vector2(500, 150)
 script = ExtResource("3_dlbku")
 
-[node name="FmodListener2D" type="FmodListener2D" parent="Listener"]
+[node name="FmodListener2D" type="FmodListener2D" parent="FmodBankLoader/Listener"]
 
-[node name="icon" type="Sprite2D" parent="Listener"]
+[node name="icon" type="Sprite2D" parent="FmodBankLoader/Listener"]
 position = Vector2(1.89996, 4.12415)
 texture = ExtResource("2_llv2n")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Listener"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="FmodBankLoader/Listener"]
 position = Vector2(0.440125, 0.440125)
 shape = SubResource("1")
 
-[node name="Label" type="Label" parent="Listener"]
+[node name="Label" type="Label" parent="FmodBankLoader/Listener"]
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
@@ -71,64 +75,70 @@ size_flags_stretch_ratio = 0.0
 text = "Listener
 Kill it with K key!"
 
-[node name="SoundArea1" type="Area2D" parent="."]
+[node name="SoundArea1" type="Area2D" parent="FmodBankLoader"]
 position = Vector2(146.558, 148.68)
 script = ExtResource("5_jxvuy")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="SoundArea1"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="FmodBankLoader/SoundArea1"]
 shape = SubResource("2")
 
-[node name="icon" type="Sprite2D" parent="SoundArea1"]
+[node name="icon" type="Sprite2D" parent="FmodBankLoader/SoundArea1"]
 self_modulate = Color(0.113725, 0.823529, 0.317647, 1)
 z_index = -1
 scale = Vector2(3, 3)
 texture = ExtResource("2_llv2n")
 
-[node name="Label2" type="Label" parent="SoundArea1"]
+[node name="Label2" type="Label" parent="FmodBankLoader/SoundArea1"]
 size_flags_stretch_ratio = 0.0
 text = "Files loaded as sounds.
 Played when entering and exiting this area.
 Several instances of the same sound can be played at the same time
 "
 
-[node name="SoundArea2" type="Area2D" parent="."]
+[node name="SoundArea2" type="Area2D" parent="FmodBankLoader"]
 position = Vector2(818.43, 97.5364)
-script = ExtResource("6_ftrrq")
+script = ExtResource("5_5p5kb")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="SoundArea2"]
+[node name="FmodEventEmitter2D" type="FmodEventEmitter2D" parent="FmodBankLoader/SoundArea2"]
+event_name = "event:/Music/Level 02"
+autoplay = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="FmodBankLoader/SoundArea2"]
 position = Vector2(52.8021, 45.8286)
 shape = SubResource("3")
 
-[node name="icon" type="Sprite2D" parent="SoundArea2"]
+[node name="icon" type="Sprite2D" parent="FmodBankLoader/SoundArea2"]
 self_modulate = Color(0.0117647, 0.956863, 0.0156863, 1)
 z_index = -1
 position = Vector2(52.3218, 46.0544)
 scale = Vector2(3, 3)
 texture = ExtResource("2_llv2n")
 
-[node name="Label3" type="Label" parent="SoundArea2"]
+[node name="Label3" type="Label" parent="FmodBankLoader/SoundArea2"]
 size_flags_stretch_ratio = 0.0
 text = "Event is unpaused when entering 
 The color changes every beat"
 
-[node name="SoundArea3" type="Area2D" parent="."]
+[node name="SoundArea3" type="Area2D" parent="FmodBankLoader"]
 position = Vector2(91.9974, 414.5)
 script = ExtResource("7_c28gt")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="SoundArea3"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="FmodBankLoader/SoundArea3"]
 position = Vector2(52.8021, 45.8286)
 shape = SubResource("3")
 
-[node name="icon" type="Sprite2D" parent="SoundArea3"]
+[node name="icon" type="Sprite2D" parent="FmodBankLoader/SoundArea3"]
 self_modulate = Color(0.827451, 0.345098, 0.0941176, 1)
 z_index = -1
 position = Vector2(52.3218, 46.0544)
 scale = Vector2(3, 3)
 texture = ExtResource("2_llv2n")
 
-[node name="Label3" type="Label" parent="SoundArea3"]
+[node name="Label3" type="Label" parent="FmodBankLoader/SoundArea3"]
 size_flags_stretch_ratio = 0.0
 text = "File loaded as Music
 Start when entering
 Stop when exiting
 Only one instance of that music can be played "
+
+[connection signal="timeline_beat" from="FmodBankLoader/SoundArea2/FmodEventEmitter2D" to="FmodBankLoader/SoundArea2" method="change_color"]

--- a/demo/high_level/Kinematic.gd
+++ b/demo/high_level/Kinematic.gd
@@ -1,0 +1,27 @@
+extends CharacterBody2D
+
+func _process(delta):
+	var direction: Vector2 = Vector2(0,0)
+	var rotation_dir = 0
+	if Input.is_action_pressed("right"):
+		direction.x += 1
+	if Input.is_action_pressed("left"):
+		direction.x -= 1
+	if Input.is_action_pressed("up"):
+		direction.y -= 1
+	if Input.is_action_pressed("down"):
+		direction.y += 1
+	if Input.is_action_pressed("rotate_right"):
+		rotation_dir = 1
+	if Input.is_action_pressed("rotate_left"):
+		rotation_dir = -1
+	direction = direction.normalized()
+	direction.x = direction.x * delta * 200
+	direction.y = direction.y * delta * 200
+	self.position += direction
+	self.rotate(rotation_dir * delta * 5)
+	if Input.is_action_pressed("lock_listener"):
+		$FmodListener2D.is_locked = !$FmodListener2D.is_locked
+	elif Input.is_action_pressed("kill"):
+		self.queue_free()
+

--- a/demo/low_level/FmodNodesTest.tscn
+++ b/demo/low_level/FmodNodesTest.tscn
@@ -1,0 +1,132 @@
+[gd_scene load_steps=10 format=3 uid="uid://dl6g18ybwc83t"]
+
+[ext_resource type="Script" path="res://low_level/FmodTest.gd" id="1_7eafu"]
+[ext_resource type="Texture2D" uid="uid://dichdnwxg2opa" path="res://icon.png" id="2_llv2n"]
+[ext_resource type="Script" path="res://low_level/Listener.gd" id="4_2l5m5"]
+[ext_resource type="Script" path="res://low_level/EnterAndLeave.gd" id="5_jxvuy"]
+[ext_resource type="Script" path="res://low_level/ChangeColor.gd" id="6_ftrrq"]
+[ext_resource type="Script" path="res://low_level/EnterandLeave2.gd" id="7_c28gt"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(87.7038, 82.621)
+
+[sub_resource type="RectangleShape2D" id="2"]
+resource_local_to_scene = true
+size = Vector2(288.124, 291.966)
+
+[sub_resource type="RectangleShape2D" id="3"]
+size = Vector2(289.938, 284.96)
+
+[node name="FmodNodesTest" type="Node2D"]
+position = Vector2(0, -3)
+script = ExtResource("1_7eafu")
+
+[node name="Node2D" type="Node2D" parent="."]
+position = Vector2(500, 500)
+
+[node name="Emitter" type="FmodEventEmitter2D" parent="Node2D"]
+event_name = "event:/Vehicles/Car Engine"
+autoplay = true
+parameters = {
+"RPM": 600.0
+}
+volume = 2.0
+self_modulate = Color(0.988235, 0, 0, 1)
+position = Vector2(-3.05176e-05, 0)
+
+[node name="Label" type="Label" parent="Node2D"]
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+grow_vertical = 2
+size_flags_stretch_ratio = 0.0
+text = "Press Space to pause/unpause
+Come closer to hear it"
+
+[node name="Sprite" type="Sprite2D" parent="Node2D"]
+self_modulate = Color(0.988235, 0, 0, 1)
+position = Vector2(-3.05176e-05, 0)
+texture = ExtResource("2_llv2n")
+
+[node name="Listener" type="CharacterBody2D" parent="."]
+position = Vector2(500, 150)
+script = ExtResource("4_2l5m5")
+
+[node name="icon" type="Sprite2D" parent="Listener"]
+position = Vector2(1.89996, 4.12415)
+texture = ExtResource("2_llv2n")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Listener"]
+position = Vector2(0.440125, 0.440125)
+shape = SubResource("1")
+
+[node name="Label" type="Label" parent="Listener"]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+grow_horizontal = 2
+size_flags_stretch_ratio = 0.0
+text = "Listener
+Kill it with K key!"
+
+[node name="SoundArea1" type="Area2D" parent="."]
+position = Vector2(146.558, 148.68)
+script = ExtResource("5_jxvuy")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="SoundArea1"]
+shape = SubResource("2")
+
+[node name="icon" type="Sprite2D" parent="SoundArea1"]
+self_modulate = Color(0.113725, 0.823529, 0.317647, 1)
+z_index = -1
+scale = Vector2(3, 3)
+texture = ExtResource("2_llv2n")
+
+[node name="Label2" type="Label" parent="SoundArea1"]
+size_flags_stretch_ratio = 0.0
+text = "Files loaded as sounds.
+Played when entering and exiting this area.
+Several instances of the same sound can be played at the same time
+"
+
+[node name="SoundArea2" type="Area2D" parent="."]
+position = Vector2(818.43, 97.5364)
+script = ExtResource("6_ftrrq")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="SoundArea2"]
+position = Vector2(52.8021, 45.8286)
+shape = SubResource("3")
+
+[node name="icon" type="Sprite2D" parent="SoundArea2"]
+self_modulate = Color(0.0117647, 0.956863, 0.0156863, 1)
+z_index = -1
+position = Vector2(52.3218, 46.0544)
+scale = Vector2(3, 3)
+texture = ExtResource("2_llv2n")
+
+[node name="Label3" type="Label" parent="SoundArea2"]
+size_flags_stretch_ratio = 0.0
+text = "Event is unpaused when entering 
+The color changes every beat"
+
+[node name="SoundArea3" type="Area2D" parent="."]
+position = Vector2(91.9974, 414.5)
+script = ExtResource("7_c28gt")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="SoundArea3"]
+position = Vector2(52.8021, 45.8286)
+shape = SubResource("3")
+
+[node name="icon" type="Sprite2D" parent="SoundArea3"]
+self_modulate = Color(0.827451, 0.345098, 0.0941176, 1)
+z_index = -1
+position = Vector2(52.3218, 46.0544)
+scale = Vector2(3, 3)
+texture = ExtResource("2_llv2n")
+
+[node name="Label3" type="Label" parent="SoundArea3"]
+size_flags_stretch_ratio = 0.0
+text = "File loaded as Music
+Start when entering
+Stop when exiting
+Only one instance of that music can be played "

--- a/demo/test/unit/test_event.gd
+++ b/demo/test/unit/test_event.gd
@@ -88,21 +88,3 @@ class TestEvent:
 		assert_true(bus.mute, "Master bus should be muted")
 		FmodServer.unmute_all_events()
 		assert_false(bus.mute, "Master bus should not be muted")
-
-#TODO: reimplement when emitters are ok.
-#	func test_assert_attached_to_node():
-#		FmodServer.attach_instance_to_node(id, sprite)
-#		var node_instance: Object = FmodServer.get_object_attached_to_instance(id)
-#		var node_instance_id: int = node_instance.get_instance_id()
-#		assert_false(node_instance == null, "Instance " + str(id) + " should be attached to Node")
-#		var id2: int = FmodServer.create_event_instance("event:/Vehicles/Car Engine")
-#		var object: Object = FmodServer.get_object_attached_to_instance(id2)
-#		assert_true(object == null, "Instance " + str(id2) + " should not be attached to any Node")
-#		FmodServer.attach_instance_to_node(id2, sprite)
-#		var object_instance_id = FmodServer.get_object_attached_to_instance(id2).get_instance_id()
-#		assert_true(node_instance_id == object_instance_id, "Both instances should be attached to same Node")
-#		FmodServer.detach_instance_from_node(id2)
-#		object = FmodServer.get_object_attached_to_instance(id2)
-#		assert_true(object == null, "Instance " + str(id2) + " should be detached")
-#		FmodServer.release_event(id2)
-#		FmodServer.detach_instance_from_node(id)

--- a/src/nodes/fmod_bank_loader.cpp
+++ b/src/nodes/fmod_bank_loader.cpp
@@ -2,6 +2,44 @@
 
 #include "fmod_server.h"
 
+#include <classes/engine.hpp>
+
 using namespace godot;
 
-void godot::FmodBankLoader::_bind_methods() {}
+void FmodBankLoader::_enter_tree() {
+#ifdef TOOLS_ENABLED
+    if (Engine::get_singleton()->is_editor_hint()) {
+        return;
+    }
+#endif
+    for (int i = 0; i < bank_paths.size(); ++i) {
+        bank.append(
+          FmodServer::get_singleton()->load_bank(bank_paths[i], FMOD_STUDIO_LOAD_BANK_NORMAL)
+        );
+    }
+}
+
+void FmodBankLoader::set_bank_paths(const Array& p_paths) {
+    bank_paths = p_paths;
+}
+
+const Array& FmodBankLoader::get_bank_paths() const {
+    return bank_paths;
+}
+
+void godot::FmodBankLoader::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("set_bank_paths", "p_paths"), &FmodBankLoader::set_bank_paths);
+    ClassDB::bind_method(D_METHOD("get_bank_paths"), &FmodBankLoader::get_bank_paths);
+
+    ADD_PROPERTY(
+      PropertyInfo(
+        Variant::ARRAY,
+        "bank_paths",
+        PROPERTY_HINT_NONE,
+        "",
+        PROPERTY_USAGE_DEFAULT
+      ),
+      "set_bank_paths",
+      "get_bank_paths"
+    );
+}

--- a/src/nodes/fmod_bank_loader.h
+++ b/src/nodes/fmod_bank_loader.h
@@ -8,8 +8,15 @@ namespace godot {
     class FmodBankLoader : public Node {
         GDCLASS(FmodBankLoader, Node)
 
-        Ref<FmodBank> bank;
-        String path;
+    public:
+        virtual void _enter_tree() override;
+
+        void set_bank_paths(const Array& p_paths);
+        const Array& get_bank_paths() const;
+
+    private:
+        Array bank;
+        Array bank_paths;
 
     public:
         static void _bind_methods();

--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -53,8 +53,10 @@ namespace godot {
         const Dictionary& get_parameters() const;
         void set_parameters(const Dictionary& p_params);
 
-        static void _bind_methods();
         static StringName& get_class_static();
+
+    protected:
+        static void _bind_methods();
 
     private:
         void set_space_attribute() const;

--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -5,10 +5,12 @@
 
 #include <fmod_server.h>
 
+#include <classes/engine.hpp>
+
 namespace godot {
 
-    struct FmodEventEmitter {
-
+    template<class Derived, class NodeType>
+    class FmodEventEmitter : public NodeType {
         Ref<FmodEvent> _event;
 
         String _event_name;
@@ -17,59 +19,348 @@ namespace godot {
         bool _is_one_shot = false;
         bool _allow_fadeout = true;
         bool _preload_event = true;
+        float _volume = true;
 
         Dictionary _params;
+        
+    public:
+        virtual void _ready() override;
+        virtual void _process(double delta) override;
+        void _notification(int p_what);
+        virtual void _exit_tree() override;
+        
+        void start();
+        void stop();
+        void play();
+        void pause();
+        const Ref<FmodEvent>& get_event() const;
+        bool is_paused();
+        void set_event_name(const String& name);
+        String get_event_name() const;
+        void set_attached(const bool attached);
+        bool is_attached() const;
+        void set_autoplay(const bool autoplay);
+        bool is_autoplay() const;
+        void set_one_shot(const bool p_is_one_shot);
+        bool is_one_shot() const;
+        void set_allow_fadeout(const bool allow_fadeout);
+        bool is_allow_fadeout() const;
+        void set_preload_event(const bool preload_event);
+        bool is_preload_event() const;
+        void set_volume(const float volume);
+        float get_volume() const;
+        void set_parameter(const String& key, const float value);
+        const Dictionary& get_parameters() const;
+        void set_parameters(const Dictionary& p_params);
 
-        void set_param(const String& key, const float value) {
-            _params[key] = value;
-            if (!_event.is_valid()) { return; }
+        static void _bind_methods();
+        static StringName& get_class_static();
+
+    private:
+        void set_space_attribute() const;
+        void apply_parameters();
+        void preload_event() const;
+        void load_event();
+    };
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_space_attribute() const {
+        static_cast<const Derived*>(this)->set_space_attribute_impl();
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::_ready() {
+#ifdef TOOLS_ENABLED
+        // ensure we only run FMOD when the game is running!
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+        
+        if (is_preload_event()) {
+            preload_event();
+        }
+
+        if (!_is_one_shot) {
+            load_event();
+            _event->set_volume(_volume);
+            apply_parameters();
+            set_space_attribute();
+        }
+
+        if (_autoplay) { play(); }
+    }
+    
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::_process(double delta) {
+#ifdef TOOLS_ENABLED
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+
+        bool should_restart{ false };
+        if (!_event.is_valid() && !_is_one_shot && _autoplay) {
+            load_event();
+            _event->set_volume(_volume);
+            apply_parameters();
+            should_restart = true;
+        }
+
+        if (!_is_one_shot && _attached && _event.is_valid()) {
+            set_space_attribute();
+        }
+
+        if (should_restart) {
+            play();
+        }
+    }
+    
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::_notification(int p_what) {
+#ifdef TOOLS_ENABLED
+        // ensure we only run FMOD when the game is running!
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+
+        if (p_what == Node::NOTIFICATION_PAUSED) {
+            pause();
+        } else if (p_what == Node::NOTIFICATION_UNPAUSED) {
+            if (is_paused()) { play(); }
+        }
+    }
+    
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::_exit_tree() {
+#ifdef TOOLS_ENABLED
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+
+        stop();
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_parameter(const String& key, const float value) {
+        _params[key] = value;
+        if (!_event.is_valid()) { return; }
+        _event->set_parameter_by_name(key, _params[key]);
+    }
+
+    template<class Derived, class NodeType>
+    const Dictionary& FmodEventEmitter<Derived, NodeType>::get_parameters() const {
+        return _params;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_parameters(const Dictionary& p_params) {
+        _params = p_params;
+        apply_parameters();
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodEventEmitter<Derived, NodeType>::is_paused() {
+        if (!_event.is_valid()) { return false; }
+        return _event->get_paused();
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::start() {
+        if (!_event.is_valid()) { return; }
+        _event->start();
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::stop() {
+        if (!_event.is_valid()) { return; }
+        if (_allow_fadeout) {
+            _event->stop(FMOD_STUDIO_STOP_ALLOWFADEOUT);
+        } else {
+            _event->stop(FMOD_STUDIO_STOP_IMMEDIATE);
+        }
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::play() {
+        if (!_event.is_valid()) { return; }
+        _event->set_paused(false);
+
+        if (!_is_one_shot) {
+            if (_attached) { set_space_attribute(); }
+            start();
+            return;
+        }
+
+        if (_attached) {
+            if (!_params.is_empty()) {
+                FmodServer::get_singleton()->play_one_shot_attached_with_params(
+                  _event_name,
+                  this,
+                  _params
+                );
+                return;
+            }
+
+            FmodServer::get_singleton()->play_one_shot_attached(_event_name, this);
+            return;
+        }
+
+        if (!_params.is_empty()) {
+            FmodServer::get_singleton()->play_one_shot_with_params(
+              _event_name,
+              this,
+              _params
+            );
+            return;
+        }
+
+        FmodServer::get_singleton()->play_one_shot(_event_name, this);
+        return;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::pause() {
+        if (!_event.is_valid()) { return; }
+        _event->set_paused(true);
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::preload_event() const {
+        Ref<FmodEventDescription> desc = FmodServer::get_singleton()->get_event(_event_name);
+        desc->load_sample_data();
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::load_event() {
+        _event = FmodServer::get_singleton()->create_event_instance(_event_name);
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::apply_parameters() {
+        if (!_event.is_valid()) { return; }
+        for (int i = 0; i < _params.keys().size(); ++i) {
+            const String& key = _params.keys()[i];
             _event->set_parameter_by_name(key, _params[key]);
         }
+    }
 
-        bool is_paused() {
-            if (!_event.is_valid()) { return false; }
-            return _event->get_paused();
+    template<class Derived, class NodeType>
+    const Ref<FmodEvent>& FmodEventEmitter<Derived, NodeType>::get_event() const {
+        return _event;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_event_name(const String& name) {
+        _event_name = name;
+    }
+
+    template<class Derived, class NodeType>
+    String FmodEventEmitter<Derived, NodeType>::get_event_name() const {
+        return _event_name;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_attached(const bool attached) {
+        _attached = attached;
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodEventEmitter<Derived, NodeType>::is_attached() const {
+        return _attached;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_autoplay(const bool autoplay) {
+        _autoplay = autoplay;
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodEventEmitter<Derived, NodeType>::is_autoplay() const {
+        return _autoplay;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_one_shot(const bool p_is_one_shot) {
+        _is_one_shot = p_is_one_shot;
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodEventEmitter<Derived, NodeType>::is_one_shot() const {
+        return _is_one_shot;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_allow_fadeout(const bool allow_fadeout) {
+        _allow_fadeout = allow_fadeout;
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodEventEmitter<Derived, NodeType>::is_allow_fadeout() const {
+        return _allow_fadeout;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_preload_event(const bool preload_event) {
+        _preload_event = preload_event;
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodEventEmitter<Derived, NodeType>::is_preload_event() const {
+        return _preload_event;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::set_volume(const float volume) {
+        _volume = volume;
+
+        if (!_event.is_valid()) {
+            return;
         }
+        _event->set_volume(volume);
+    }
 
-        void play() {
-            if (!_event.is_valid()) { return; }
-            _event->set_paused(false);
-        }
+    template<class Derived, class NodeType>
+    float FmodEventEmitter<Derived, NodeType>::get_volume() const {
+        return _volume;
+    }
 
-        void pause() {
-            if (!_event.is_valid()) { return; }
-            _event->set_paused(true);
-        }
+    template<class Derived, class NodeType>
+    StringName& FmodEventEmitter<Derived, NodeType>::get_class_static() {
+        return Derived::get_class_static();
+    }
 
-        void set_event_name(const String& name) {
-            if (name.begins_with("event:/")) {
-                _event_name = name;
-            } else {
-                _event_name = "event:/" + name;
-            }
-        }
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("set_parameter", "key", "value"), &Derived::set_parameter);
+        ClassDB::bind_method(D_METHOD("is_paused"), &Derived::is_paused);
+        ClassDB::bind_method(D_METHOD("play"), &Derived::play);
+        ClassDB::bind_method(D_METHOD("pause"), &Derived::pause);
+        ClassDB::bind_method(D_METHOD("set_event_name", "event_name"), &Derived::set_event_name);
+        ClassDB::bind_method(D_METHOD("get_event_name"), &Derived::get_event_name);
+        ClassDB::bind_method(D_METHOD("set_attached", "attached"), &Derived::set_attached);
+        ClassDB::bind_method(D_METHOD("is_attached"), &Derived::is_attached);
+        ClassDB::bind_method(D_METHOD("set_autoplay", "_autoplay"), &Derived::set_autoplay);
+        ClassDB::bind_method(D_METHOD("is_autoplay"), &Derived::is_autoplay);
+        ClassDB::bind_method(D_METHOD("set_one_shot", "_is_one_shot"), &Derived::set_one_shot);
+        ClassDB::bind_method(D_METHOD("is_one_shot"), &Derived::is_one_shot);
+        ClassDB::bind_method(D_METHOD("set_allow_fadeout", "allow_fadeout"), &Derived::set_allow_fadeout);
+        ClassDB::bind_method(D_METHOD("is_allow_fadeout"), &Derived::is_allow_fadeout);
+        ClassDB::bind_method(D_METHOD("set_preload_event", "preload_event"), &Derived::set_preload_event);
+        ClassDB::bind_method(D_METHOD("is_preload_event"), &Derived::is_preload_event);
+        ClassDB::bind_method(D_METHOD("_notification", "p_what"), &Derived::_notification);
+        ClassDB::bind_method(D_METHOD("get_parameters"), &Derived::get_parameters);
+        ClassDB::bind_method(D_METHOD("set_parameters", "p_parameters"), &Derived::set_parameters);
+        ClassDB::bind_method(D_METHOD("get_volume"), &Derived::get_volume);
+        ClassDB::bind_method(D_METHOD("set_volume", "p_volume"), &Derived::set_volume);
 
-        String get_event_name() { return _event_name; }
+        ADD_PROPERTY(PropertyInfo(Variant::STRING, "event_name",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_event_name", "get_event_name");
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "attached",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_attached", "is_attached");
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_autoplay", "is_autoplay");
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_one_shot", "is_one_shot");
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_fadeout",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_allow_fadeout", "is_allow_fadeout");
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "preload_event",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_preload_event", "is_preload_event");
+        ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "parameters",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_parameters", "get_parameters");
+        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), "set_volume", "get_volume");
 
-        void set_attached(const bool attached) { this->_attached = attached; }
-
-        bool is_attached() const { return _attached; }
-
-        void set_autoplay(const bool autoplay) { this->_autoplay = autoplay; }
-
-        bool is_autoplay() const { return _autoplay; }
-
-        void set_looped(const bool looped) { this->_is_one_shot = looped; }
-
-        bool is_looped() const { return _is_one_shot; }
-
-        void set_allow_fadeout(const bool allow_fadeout) { this->_allow_fadeout = allow_fadeout; }
-
-        bool is_allow_fadeout() const { return _allow_fadeout; }
-
-        void set_preload_event(const bool preload_event) { this->_preload_event = preload_event; }
-
-        bool is_preload_event() const { return _preload_event; }
-    };
+        ADD_SIGNAL(MethodInfo("timeline_beat", PropertyInfo(Variant::DICTIONARY, "params")));
+        ADD_SIGNAL(MethodInfo("timeline_marker", PropertyInfo(Variant::DICTIONARY, "params")));
+        ADD_SIGNAL(MethodInfo("sound_played", PropertyInfo(Variant::DICTIONARY, "params")));
+        ADD_SIGNAL(MethodInfo("sound_stopped", PropertyInfo(Variant::DICTIONARY, "params")));
+    }
 }// namespace godot
 #endif// GODOTFMOD_FMOD_EVENT_EMITTER_H

--- a/src/nodes/fmod_event_emitter_2d.cpp
+++ b/src/nodes/fmod_event_emitter_2d.cpp
@@ -1,127 +1,27 @@
 #include <nodes/fmod_event_emitter_2d.h>
 
-#include <classes/engine.hpp>
-
 using namespace godot;
 
-void FmodEventEmitter2D::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("set_param", "key", "value"), &FmodEventEmitter2D::set_param);
-    ClassDB::bind_method(D_METHOD("is_paused"), &FmodEventEmitter2D::is_paused);
-    ClassDB::bind_method(D_METHOD("play"), &FmodEventEmitter2D::play);
-    ClassDB::bind_method(D_METHOD("pause"), &FmodEventEmitter2D::pause);
-    ClassDB::bind_method(D_METHOD("set_event_name", "event_name"), &FmodEventEmitter2D::set_event_name);
-    ClassDB::bind_method(D_METHOD("get_event_name"), &FmodEventEmitter2D::get_event_name);
-    ClassDB::bind_method(D_METHOD("set_attached", "attached"), &FmodEventEmitter2D::set_attached);
-    ClassDB::bind_method(D_METHOD("is_attached"), &FmodEventEmitter2D::is_attached);
-    ClassDB::bind_method(D_METHOD("set_autoplay", "_autoplay"), &FmodEventEmitter2D::set_autoplay);
-    ClassDB::bind_method(D_METHOD("is_autoplay"), &FmodEventEmitter2D::is_autoplay);
-    ClassDB::bind_method(D_METHOD("set_looped", "_is_one_shot"), &FmodEventEmitter2D::set_looped);
-    ClassDB::bind_method(D_METHOD("is_looped"), &FmodEventEmitter2D::is_looped);
-    ClassDB::bind_method(D_METHOD("set_allow_fadeout", "allow_fadeout"), &FmodEventEmitter2D::set_allow_fadeout);
-    ClassDB::bind_method(D_METHOD("is_allow_fadeout"), &FmodEventEmitter2D::is_allow_fadeout);
-    ClassDB::bind_method(D_METHOD("set_preload_event", "preload_event"), &FmodEventEmitter2D::set_preload_event);
-    ClassDB::bind_method(D_METHOD("is_preload_event"), &FmodEventEmitter2D::is_preload_event);
-    ClassDB::bind_method(D_METHOD("_notification", "p_what"), &FmodEventEmitter2D::_notification);
-
-    ADD_PROPERTY(PropertyInfo(Variant::STRING, "event_name",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_event_name", "get_event_name");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "attached",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_attached", "is_attached");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_autoplay", "is_autoplay");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "looped",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_looped", "is_looped");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_fadeout",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_allow_fadeout", "is_allow_fadeout");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "preload_event",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_preload_event", "is_preload_event");
-
-    ADD_SIGNAL(MethodInfo("timeline_beat", PropertyInfo(Variant::DICTIONARY, "params")));
-    ADD_SIGNAL(MethodInfo("timeline_marker", PropertyInfo(Variant::DICTIONARY, "params")));
-    ADD_SIGNAL(MethodInfo("sound_played", PropertyInfo(Variant::DICTIONARY, "params")));
-    ADD_SIGNAL(MethodInfo("sound_stopped", PropertyInfo(Variant::DICTIONARY, "params")));
+void FmodEventEmitter2D::set_space_attribute_impl() const {
+    get_event()->set_2d_attributes(get_global_transform());
 }
 
 void FmodEventEmitter2D::_ready() {
-    // ensure we only run FMOD when the game is running!
-    if (Engine::get_singleton()->is_editor_hint()) { return; }
-
-    if (internal_emitter._preload_event) {
-        Ref<FmodEventDescription> desc = FmodServer::get_singleton()->get_event(internal_emitter._event_name);
-        desc->load_sample_data();
-    }
-
-    internal_emitter._event = FmodServer::get_singleton()->create_event_instance(internal_emitter._event_name);
-
-    for (int i = 0; i < internal_emitter._params.keys().size(); ++i) {
-        auto key = internal_emitter._params.keys()[i];
-        internal_emitter._event->set_parameter_by_name(key, internal_emitter._params[key]);
-    }
-
-    internal_emitter._event->set_2d_attributes(get_transform());
-    if (internal_emitter._autoplay) { play(); }
+    FmodEventEmitter<FmodEventEmitter2D, Node2D>::_ready();
 }
 
 void FmodEventEmitter2D::_process(double delta) {
-    if (!internal_emitter._event.is_valid() && !internal_emitter._is_one_shot && internal_emitter._autoplay) {
-        internal_emitter._event = FmodServer::get_singleton()->create_event_instance(internal_emitter._event_name);
-    }
-
-    if (internal_emitter._attached && internal_emitter._event.is_valid()) { internal_emitter._event->set_2d_attributes(get_transform()); }
+    FmodEventEmitter<FmodEventEmitter2D, Node2D>::_process(delta);
 }
 
 void FmodEventEmitter2D::_notification(int p_what) {
-    // ensure we only run FMOD when the game is running!
-    if (Engine::get_singleton()->is_editor_hint()) { return; }
-    if (p_what == NOTIFICATION_PAUSED) {
-        pause();
-    } else if (p_what == NOTIFICATION_UNPAUSED) {
-        if (is_paused()) { play(); }
-    }
+    FmodEventEmitter<FmodEventEmitter2D, Node2D>::_notification(p_what);
 }
 
 void FmodEventEmitter2D::_exit_tree() {
-    if (!internal_emitter._event.is_valid()) { return; }
-
-    if (internal_emitter._allow_fadeout) {
-        internal_emitter._event->stop(FMOD_STUDIO_STOP_ALLOWFADEOUT);
-    } else {
-        internal_emitter._event->stop(FMOD_STUDIO_STOP_IMMEDIATE);
-    }
+    FmodEventEmitter<FmodEventEmitter2D, Node2D>::_exit_tree();
 }
 
-void FmodEventEmitter2D::set_param(const String& key, const float value) {
-    internal_emitter.set_param(key, value);
+void FmodEventEmitter2D::_bind_methods() {
+    FmodEventEmitter<FmodEventEmitter2D, Node2D>::_bind_methods();
 }
-
-bool FmodEventEmitter2D::is_paused() {
-    return internal_emitter.is_paused();
-}
-
-void FmodEventEmitter2D::play() {
-    internal_emitter.play();
-}
-
-void FmodEventEmitter2D::pause() {
-    internal_emitter.pause();
-}
-
-void FmodEventEmitter2D::set_event_name(const String& name) {
-    internal_emitter.set_event_name(name);
-}
-
-String FmodEventEmitter2D::get_event_name() { return internal_emitter._event_name; }
-
-void FmodEventEmitter2D::set_attached(const bool attached) { internal_emitter._attached = attached; }
-
-bool FmodEventEmitter2D::is_attached() const { return internal_emitter._attached; }
-
-void FmodEventEmitter2D::set_autoplay(const bool autoplay) { internal_emitter._autoplay = autoplay; }
-
-bool FmodEventEmitter2D::is_autoplay() const { return internal_emitter._autoplay; }
-
-void FmodEventEmitter2D::set_looped(const bool looped) { internal_emitter._is_one_shot = !looped; }
-
-bool FmodEventEmitter2D::is_looped() const { return !internal_emitter._is_one_shot; }
-
-void FmodEventEmitter2D::set_allow_fadeout(const bool allow_fadeout) { internal_emitter._allow_fadeout = allow_fadeout; }
-
-bool FmodEventEmitter2D::is_allow_fadeout() const { return internal_emitter._allow_fadeout; }
-
-void FmodEventEmitter2D::set_preload_event(const bool preload_event) { internal_emitter._preload_event = preload_event; }
-
-bool FmodEventEmitter2D::is_preload_event() const { return internal_emitter._preload_event; }

--- a/src/nodes/fmod_event_emitter_2d.h
+++ b/src/nodes/fmod_event_emitter_2d.h
@@ -7,10 +7,12 @@
 #include <classes/node2d.hpp>
 
 namespace godot {
-    class FmodEventEmitter2D : public Node2D {
+    class FmodEventEmitter2D : public FmodEventEmitter<FmodEventEmitter2D, Node2D>  {
+        friend class FmodEventEmitter<FmodEventEmitter2D, Node2D>;
         GDCLASS(FmodEventEmitter2D, Node2D)
 
-        FmodEventEmitter internal_emitter;
+    private:
+        void set_space_attribute_impl() const;
 
     public:
         FmodEventEmitter2D() = default;
@@ -20,23 +22,6 @@ namespace godot {
         virtual  void _process(double delta) override;
         void _notification(int p_what);
         virtual void _exit_tree() override;
-
-        void set_param(const String& key, const float value);
-        bool is_paused();
-        void play();
-        void pause();
-        void set_event_name(const String& name);
-        String get_event_name();
-        void set_attached(const bool attached);
-        bool is_attached() const;
-        void set_autoplay(const bool autoplay);
-        bool is_autoplay() const;
-        void set_looped(const bool looped);
-        bool is_looped() const;
-        void set_allow_fadeout(const bool allow_fadeout);
-        bool is_allow_fadeout() const;
-        void set_preload_event(const bool preload_event);
-        bool is_preload_event() const;
 
         static void _bind_methods();
     };

--- a/src/nodes/fmod_event_emitter_3d.cpp
+++ b/src/nodes/fmod_event_emitter_3d.cpp
@@ -1,127 +1,27 @@
 #include <nodes/fmod_event_emitter_3d.h>
 
-#include <classes/engine.hpp>
-
 using namespace godot;
 
-void FmodEventEmitter3D::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("set_param", "key", "value"), &FmodEventEmitter3D::set_param);
-    ClassDB::bind_method(D_METHOD("is_paused"), &FmodEventEmitter3D::is_paused);
-    ClassDB::bind_method(D_METHOD("play"), &FmodEventEmitter3D::play);
-    ClassDB::bind_method(D_METHOD("pause"), &FmodEventEmitter3D::pause);
-    ClassDB::bind_method(D_METHOD("set_event_name", "event_name"), &FmodEventEmitter3D::set_event_name);
-    ClassDB::bind_method(D_METHOD("get_event_name"), &FmodEventEmitter3D::get_event_name);
-    ClassDB::bind_method(D_METHOD("set_attached", "attached"), &FmodEventEmitter3D::set_attached);
-    ClassDB::bind_method(D_METHOD("is_attached"), &FmodEventEmitter3D::is_attached);
-    ClassDB::bind_method(D_METHOD("set_autoplay", "_autoplay"), &FmodEventEmitter3D::set_autoplay);
-    ClassDB::bind_method(D_METHOD("is_autoplay"), &FmodEventEmitter3D::is_autoplay);
-    ClassDB::bind_method(D_METHOD("set_looped", "_is_one_shot"), &FmodEventEmitter3D::set_looped);
-    ClassDB::bind_method(D_METHOD("is_looped"), &FmodEventEmitter3D::is_looped);
-    ClassDB::bind_method(D_METHOD("set_allow_fadeout", "allow_fadeout"), &FmodEventEmitter3D::set_allow_fadeout);
-    ClassDB::bind_method(D_METHOD("is_allow_fadeout"), &FmodEventEmitter3D::is_allow_fadeout);
-    ClassDB::bind_method(D_METHOD("set_preload_event", "preload_event"), &FmodEventEmitter3D::set_preload_event);
-    ClassDB::bind_method(D_METHOD("is_preload_event"), &FmodEventEmitter3D::is_preload_event);
-    ClassDB::bind_method(D_METHOD("_notification", "p_what"), &FmodEventEmitter3D::_notification);
-
-    ADD_PROPERTY(PropertyInfo(Variant::STRING, "event_name",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_event_name", "get_event_name");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "attached",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_attached", "is_attached");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_autoplay", "is_autoplay");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "looped",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_looped", "is_looped");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_fadeout",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_allow_fadeout", "is_allow_fadeout");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "preload_event",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_preload_event", "is_preload_event");
-
-    ADD_SIGNAL(MethodInfo("timeline_beat", PropertyInfo(Variant::DICTIONARY, "params")));
-    ADD_SIGNAL(MethodInfo("timeline_marker", PropertyInfo(Variant::DICTIONARY, "params")));
-    ADD_SIGNAL(MethodInfo("sound_played", PropertyInfo(Variant::DICTIONARY, "params")));
-    ADD_SIGNAL(MethodInfo("sound_stopped", PropertyInfo(Variant::DICTIONARY, "params")));
+void FmodEventEmitter3D::set_space_attribute_impl() const {
+    get_event()->set_3d_attributes(get_transform());
 }
 
 void FmodEventEmitter3D::_ready() {
-    // ensure we only run FMOD when the game is running!
-    if (Engine::get_singleton()->is_editor_hint()) { return; }
-
-    if (internal_emitter._preload_event) {
-        Ref<FmodEventDescription> desc = FmodServer::get_singleton()->get_event(internal_emitter._event_name);
-        desc->load_sample_data();
-    }
-
-    internal_emitter._event = FmodServer::get_singleton()->create_event_instance(internal_emitter._event_name);
-
-    for (int i = 0; i < internal_emitter._params.keys().size(); ++i) {
-        auto key = internal_emitter._params.keys()[i];
-        internal_emitter._event->set_parameter_by_name(key, internal_emitter._params[key]);
-    }
-
-    internal_emitter._event->set_3d_attributes(get_transform());
-    if (internal_emitter._autoplay) { play(); }
+    FmodEventEmitter<FmodEventEmitter3D, Node3D>::_ready();
 }
 
 void FmodEventEmitter3D::_process(double delta) {
-    if (!internal_emitter._event.is_valid() && !internal_emitter._is_one_shot && internal_emitter._autoplay) {
-        internal_emitter._event = FmodServer::get_singleton()->create_event_instance(internal_emitter._event_name);
-    }
-
-    if (internal_emitter._attached && internal_emitter._event.is_valid()) { internal_emitter._event->set_3d_attributes(get_transform()); }
+    FmodEventEmitter<FmodEventEmitter3D, Node3D>::_process(delta);
 }
 
 void FmodEventEmitter3D::_notification(int p_what) {
-    // ensure we only run FMOD when the game is running!
-    if (Engine::get_singleton()->is_editor_hint()) { return; }
-    if (p_what == NOTIFICATION_PAUSED) {
-        pause();
-    } else if (p_what == NOTIFICATION_UNPAUSED) {
-        if (is_paused()) { play(); }
-    }
+    FmodEventEmitter<FmodEventEmitter3D, Node3D>::_notification(p_what);
 }
 
 void FmodEventEmitter3D::_exit_tree() {
-    if (!internal_emitter._event.is_valid()) { return; }
-
-    if (internal_emitter._allow_fadeout) {
-        internal_emitter._event->stop(FMOD_STUDIO_STOP_ALLOWFADEOUT);
-    } else {
-        internal_emitter._event->stop(FMOD_STUDIO_STOP_IMMEDIATE);
-    }
+    FmodEventEmitter<FmodEventEmitter3D, Node3D>::_exit_tree();
 }
 
-void FmodEventEmitter3D::set_param(const String& key, const float value) {
-    internal_emitter.set_param(key, value);
+void FmodEventEmitter3D::_bind_methods() {
+    FmodEventEmitter<FmodEventEmitter3D, Node3D>::_bind_methods();
 }
-
-bool FmodEventEmitter3D::is_paused() {
-    return internal_emitter.is_paused();
-}
-
-void FmodEventEmitter3D::play() {
-    internal_emitter.play();
-}
-
-void FmodEventEmitter3D::pause() {
-    internal_emitter.pause();
-}
-
-void FmodEventEmitter3D::set_event_name(const String& name) {
-    internal_emitter.set_event_name(name);
-}
-
-String FmodEventEmitter3D::get_event_name() { return internal_emitter._event_name; }
-
-void FmodEventEmitter3D::set_attached(const bool attached) { internal_emitter._attached = attached; }
-
-bool FmodEventEmitter3D::is_attached() const { return internal_emitter._attached; }
-
-void FmodEventEmitter3D::set_autoplay(const bool autoplay) { internal_emitter._autoplay = autoplay; }
-
-bool FmodEventEmitter3D::is_autoplay() const { return internal_emitter._autoplay; }
-
-void FmodEventEmitter3D::set_looped(const bool looped) { internal_emitter._is_one_shot = !looped; }
-
-bool FmodEventEmitter3D::is_looped() const { return !internal_emitter._is_one_shot; }
-
-void FmodEventEmitter3D::set_allow_fadeout(const bool allow_fadeout) { internal_emitter._allow_fadeout = allow_fadeout; }
-
-bool FmodEventEmitter3D::is_allow_fadeout() const { return internal_emitter._allow_fadeout; }
-
-void FmodEventEmitter3D::set_preload_event(const bool preload_event) { internal_emitter._preload_event = preload_event; }
-
-bool FmodEventEmitter3D::is_preload_event() const { return internal_emitter._preload_event; }

--- a/src/nodes/fmod_event_emitter_3d.h
+++ b/src/nodes/fmod_event_emitter_3d.h
@@ -6,10 +6,12 @@
 #include "fmod_event_emitter.h"
 
 namespace godot {
-    class FmodEventEmitter3D : public Node3D {
+    class FmodEventEmitter3D : public FmodEventEmitter<FmodEventEmitter3D, Node3D> {
+        friend class FmodEventEmitter<FmodEventEmitter3D, Node3D>;
         GDCLASS(FmodEventEmitter3D, Node3D)
 
-        FmodEventEmitter internal_emitter;
+    private:
+        void set_space_attribute_impl() const;
 
     public:
         FmodEventEmitter3D() = default;
@@ -19,23 +21,6 @@ namespace godot {
         virtual  void _process(double delta) override;
         void _notification(int p_what);
         virtual void _exit_tree() override;
-
-        void set_param(const String& key, const float value);
-        bool is_paused();
-        void play();
-        void pause();
-        void set_event_name(const String& name);
-        String get_event_name();
-        void set_attached(const bool attached);
-        bool is_attached() const;
-        void set_autoplay(const bool autoplay);
-        bool is_autoplay() const;
-        void set_looped(const bool looped);
-        bool is_looped() const;
-        void set_allow_fadeout(const bool allow_fadeout);
-        bool is_allow_fadeout() const;
-        void set_preload_event(const bool preload_event);
-        bool is_preload_event() const;
 
         static void _bind_methods();
     };

--- a/src/nodes/fmod_listener.h
+++ b/src/nodes/fmod_listener.h
@@ -1,8 +1,172 @@
 #ifndef GODOTFMOD_FMOD_LISTENER_H
 #define GODOTFMOD_FMOD_LISTENER_H
 
+#include <fmod_server.h>
+
+#include <classes/engine.hpp>
+
 namespace godot {
-    struct FmodListener {};
+    template<class Derived, class NodeType>
+    class FmodListener : public NodeType {
+    public:
+        virtual void _ready() override;
+        virtual void _exit_tree() override;
+
+        void set_listener_index(const int index);
+        int get_listener_index() const;
+
+        void set_locked(const bool locked);
+        bool get_locked() const;
+
+        void set_listener_weight(const float p_weight);
+        float get_listener_weight() const;
+
+        static StringName& get_class_static();
+
+        FmodListener();
+        ~FmodListener() = default;
+
+    private:
+        float _weight;
+        int _listener_index;
+        bool _is_locked;
+
+        bool _is_added;
+
+    protected:
+        static void _bind_methods();
+    };
+
+    template<class Derived, class NodeType>
+    void FmodListener<Derived, NodeType>::_ready() {
+#ifdef TOOLS_ENABLED
+        // ensure we only run FMOD when the game is running!
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+
+        FmodServer::get_singleton()->add_listener(_listener_index, this);
+        FmodServer::get_singleton()->set_listener_lock(_listener_index, _is_locked);
+
+        _is_added = true;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodListener<Derived, NodeType>::_exit_tree() {
+#ifdef TOOLS_ENABLED
+        // ensure we only run FMOD when the game is running!
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+
+        FmodServer::get_singleton()->remove_listener(_listener_index);
+        _is_added = false;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodListener<Derived, NodeType>::set_listener_index(const int index) {
+        _listener_index = index;
+    }
+
+    template<class Derived, class NodeType>
+    int FmodListener<Derived, NodeType>::get_listener_index() const {
+        return _listener_index;
+    }
+
+    template<class Derived, class NodeType>
+    void FmodListener<Derived, NodeType>::set_locked(const bool locked) {
+        _is_locked = locked;
+
+        if (!_is_added) {
+            return;
+        }
+
+        FmodServer::get_singleton()->set_listener_lock(_listener_index, locked);
+    }
+
+    template<class Derived, class NodeType>
+    bool FmodListener<Derived, NodeType>::get_locked() const {
+        if (!_is_added) {
+            return _is_locked;
+        }
+
+        return FmodServer::get_singleton()->get_listener_lock(_listener_index);
+    }
+
+    template<class Derived, class NodeType>
+    void FmodListener<Derived, NodeType>::set_listener_weight(const float p_weight) {
+        _weight = p_weight;
+
+        if (!_is_added) {
+            return;
+        }
+
+        FmodServer::get_singleton()->set_system_listener_weight(_listener_index, p_weight);
+    }
+
+    template<class Derived, class NodeType>
+    float FmodListener<Derived, NodeType>::get_listener_weight() const {
+        if (!_is_added) {
+            return _weight;
+        }
+
+        return FmodServer::get_singleton()->get_system_listener_weight(_listener_index);
+    }
+
+    template<class Derived, class NodeType>
+    FmodListener<Derived, NodeType>::FmodListener() :
+      NodeType(),
+      _weight(1.0),
+      _listener_index(0),
+      _is_locked(false),
+      _is_added(false) {}
+
+    template<class Derived, class NodeType>
+    void FmodListener<Derived, NodeType>::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("set_listener_index", "index"), &Derived::set_listener_index);
+        ClassDB::bind_method(D_METHOD("get_listener_index"), &Derived::get_listener_index);
+        ClassDB::bind_method(D_METHOD("set_locked", "locked"), &Derived::set_locked);
+        ClassDB::bind_method(D_METHOD("get_locked"), &Derived::get_locked);
+        ClassDB::bind_method(D_METHOD("set_listener_weight", "p_weight"), &Derived::set_listener_weight);
+        ClassDB::bind_method(D_METHOD("get_listener_weight"), &Derived::get_listener_weight);
+
+        ADD_PROPERTY(
+          PropertyInfo(
+            Variant::INT,
+            "listener_index",
+            PROPERTY_HINT_NONE,
+            "",
+            PROPERTY_USAGE_EDITOR
+          ),
+          "set_listener_index",
+          "get_listener_index"
+        );
+        ADD_PROPERTY(
+          PropertyInfo(
+            Variant::BOOL,
+            "is_locked",
+            PROPERTY_HINT_NONE,
+            "",
+            PROPERTY_USAGE_DEFAULT
+          ),
+          "set_locked",
+          "get_locked"
+        );
+        ADD_PROPERTY(
+          PropertyInfo(
+            Variant::FLOAT,
+            "weight",
+            PROPERTY_HINT_NONE,
+            "",
+            PROPERTY_USAGE_DEFAULT
+          ),
+          "set_listener_weight",
+          "get_listener_weight"
+        );
+    }
+
+    template<class Derived, class NodeType>
+    StringName& FmodListener<Derived, NodeType>::get_class_static() {
+        return Derived::get_class_static();
+    }
 }// namespace godot
 
 #endif// GODOTFMOD_FMOD_LISTENER_H

--- a/src/nodes/fmod_listener_2d.cpp
+++ b/src/nodes/fmod_listener_2d.cpp
@@ -1,7 +1,15 @@
 #include "fmod_listener_2d.h"
 
-#include "fmod_server.h"
-
 using namespace godot;
 
-void godot::FmodListener2D::_bind_methods() {}
+void FmodListener2D::_bind_methods() {
+    FmodListener<FmodListener2D, Node2D>::_bind_methods();
+}
+
+void FmodListener2D::_ready() {
+    FmodListener<FmodListener2D, Node2D>::_ready();
+}
+
+void FmodListener2D::_exit_tree() {
+    FmodListener<FmodListener2D, Node2D>::_exit_tree();
+}

--- a/src/nodes/fmod_listener_2d.h
+++ b/src/nodes/fmod_listener_2d.h
@@ -6,13 +6,15 @@
 #include "fmod_listener.h"
 
 namespace godot {
-    class FmodListener2D : public Node2D {
+    class FmodListener2D : public FmodListener<FmodListener2D, Node2D> {
         GDCLASS(FmodListener2D, Node2D)
 
-        FmodListener internal_emitter;
     public:
+        virtual void _ready() override;
+        virtual void _exit_tree() override;
 
     protected:
+
         static void _bind_methods();
     };
 }// namespace godot

--- a/src/nodes/fmod_listener_3d.cpp
+++ b/src/nodes/fmod_listener_3d.cpp
@@ -4,4 +4,14 @@
 
 using namespace godot;
 
-void godot::FmodListener3D::_bind_methods() {}
+void FmodListener3D::_bind_methods() {
+    FmodListener<FmodListener3D, Node3D>::_bind_methods();
+}
+
+void FmodListener3D::_ready() {
+    FmodListener<FmodListener3D, Node3D>::_ready();
+}
+
+void FmodListener3D::_exit_tree() {
+    FmodListener<FmodListener3D, Node3D>::_exit_tree();
+}

--- a/src/nodes/fmod_listener_3d.h
+++ b/src/nodes/fmod_listener_3d.h
@@ -6,13 +6,15 @@
 #include "fmod_listener.h"
 
 namespace godot {
-    class FmodListener3D : public Node3D {
+    class FmodListener3D : public FmodListener<FmodListener3D, Node3D> {
         GDCLASS(FmodListener3D, Node3D)
 
-        FmodListener internal_emitter;
     public:
+        virtual void _ready() override;
+        virtual void _exit_tree() override;
 
     protected:
+
         static void _bind_methods();
     };
 }// namespace godot


### PR DESCRIPTION
This simplify emitters code using a CRTP.  
This brings back gdscript fmod event emitter we had in 3.x in cpp.  
Next steps are fmod nodes.  
I think we can merge `godot-4.x` in `master` when this one is merged.